### PR TITLE
Support 21555 Remove unused verbatimCollectors and collectorGroupUuid

### DIFF
--- a/src/main/java/ca/gc/aafc/collection/api/dto/CollectingEventDto.java
+++ b/src/main/java/ca/gc/aafc/collection/api/dto/CollectingEventDto.java
@@ -35,8 +35,7 @@ public class CollectingEventDto {
 
   @JsonApiId
   private UUID uuid;
-  private UUID collectorGroupUuid;
-
+  
   private String group;
 
   private String createdBy;
@@ -47,7 +46,6 @@ public class CollectingEventDto {
 
   private Integer dwcCoordinateUncertaintyInMeters;
   private String dwcVerbatimCoordinates;
-  private String verbatimCollectors;
   private String dwcRecordedBy;
 
   @IgnoreDinaMapping

--- a/src/main/java/ca/gc/aafc/collection/api/entities/CollectingEvent.java
+++ b/src/main/java/ca/gc/aafc/collection/api/entities/CollectingEvent.java
@@ -57,9 +57,6 @@ public class CollectingEvent implements DinaEntity {
   @Column(name = "_group")
   private String group;
 
-  // Not a Foreign Key, we would not use the UUID if it was.
-  private UUID collectorGroupUuid;
-
   // Might not be the final choice to store lat/long
   private Double dwcDecimalLatitude;
   private Double dwcDecimalLongitude;
@@ -83,8 +80,7 @@ public class CollectingEvent implements DinaEntity {
   private Byte endEventDateTimePrecision;
 
   private String verbatimEventDateTime;
-  private String verbatimCollectors;
-
+  
   @Column(insertable = false, updatable = false)
   private OffsetDateTime createdOn;
 

--- a/src/main/resources/db/changelog/db.changelog-master.xml
+++ b/src/main/resources/db/changelog/db.changelog-master.xml
@@ -8,4 +8,5 @@
   <include file="db/changelog/migrations/5-Rename_previous_location_fields.xml"/>
   <include file="db/changelog/migrations/6-Add_dwcRecordedBy_collecting_event.xml"/>
   <include file="db/changelog/migrations/7-Add_dwcVerbatimLocality_etc_collecting_event.xml"/>
+  <include file="db/changelog/migrations/8-Remove_verbatimCollectors_etc_collecting_event.xml"/>
 </databaseChangeLog>

--- a/src/main/resources/db/changelog/migrations/8-Remove_verbatimCollectors_etc_collecting_event.xml
+++ b/src/main/resources/db/changelog/migrations/8-Remove_verbatimCollectors_etc_collecting_event.xml
@@ -1,0 +1,15 @@
+<?xml version="1.1" encoding="UTF-8" standalone="no" ?>
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.6.xsd"
+        context="schema-change">
+
+    <changeSet context="schema-change" id="8-Remove_verbatimCollectors_etc_collecting_event" author="xgan">
+        <dropColumn tableName="collecting_event">
+            <column name="verbatim_collectors"/>
+            <column name="collector_group_uuid"/>
+        </dropColumn>
+    </changeSet>
+
+</databaseChangeLog>

--- a/src/test/java/ca/gc/aafc/collection/api/openapi/CollectingEventOpenApiIT.java
+++ b/src/test/java/ca/gc/aafc/collection/api/openapi/CollectingEventOpenApiIT.java
@@ -66,8 +66,6 @@ public class CollectingEventOpenApiIT extends BaseRestAssuredTest {
     ce.setDwcDecimalLongitude(1.2);
     ce.setVerbatimEventDateTime("a cold winter morning in the winter of 2099");
     ce.setDwcCoordinateUncertaintyInMeters(2);
-    ce.setCollectorGroupUuid(UUID.randomUUID());
-    ce.setVerbatimCollectors("Jack and Jane");
     ce.setStartEventDateTime(ISODateTime.parse("2007-12-03T10:15:30").toString());
     ce.setEndEventDateTime(ISODateTime.parse("2007-12-04T11:20:20").toString());
     ce.setDwcVerbatimCoordinates("26.089, 106.36");

--- a/src/test/java/ca/gc/aafc/collection/api/repository/CollectingEventRepositoryIT.java
+++ b/src/test/java/ca/gc/aafc/collection/api/repository/CollectingEventRepositoryIT.java
@@ -49,7 +49,6 @@ public class CollectingEventRepositoryIT extends CollectionModuleBaseIT {
       .startEventDateTime(LocalDateTime.of(startDate, startTime))
       .startEventDateTimePrecision((byte) 8)
       .endEventDateTime(LocalDateTime.of(endDate, endTime))
-      .verbatimCollectors("Jack and Jane")
       .endEventDateTimePrecision((byte) 8)
       .verbatimEventDateTime("XI-02-1798")
       .dwcDecimalLatitude(26.089)
@@ -58,7 +57,6 @@ public class CollectingEventRepositoryIT extends CollectionModuleBaseIT {
       .dwcVerbatimCoordinates("26.089, 106.36")
       .attachment(List.of(UUID.randomUUID()))
       .collectors(List.of(UUID.randomUUID()))
-      .collectorGroupUuid(UUID.randomUUID())
       .dwcRecordedBy(dwcRecordedBy)
       .dwcVerbatimLocality(dwcVerbatimLocality)
       .dwcGeoreferencedDate(dwcGeoreferencedDate)
@@ -95,8 +93,6 @@ public class CollectingEventRepositoryIT extends CollectionModuleBaseIT {
     assertEquals(
       testCollectingEvent.getCollectors().get(0).toString(),
       collectingEventDto.getCollectors().get(0).getId());
-    assertEquals("Jack and Jane", testCollectingEvent.getVerbatimCollectors());
-    assertEquals(testCollectingEvent.getCollectorGroupUuid(), collectingEventDto.getCollectorGroupUuid());
     assertEquals(dwcVerbatimLocality, collectingEventDto.getDwcVerbatimLocality());
     assertEquals(dwcGeoreferenceSources, collectingEventDto.getDwcGeoreferenceSources());
     assertEquals(dwcGeoreferencedDate, collectingEventDto.getDwcGeoreferencedDate());
@@ -108,8 +104,6 @@ public class CollectingEventRepositoryIT extends CollectionModuleBaseIT {
     CollectingEventDto ce = new CollectingEventDto();
     ce.setUuid(UUID.randomUUID());
     ce.setGroup("test group");
-    ce.setCollectorGroupUuid(UUID.randomUUID());
-    ce.setVerbatimCollectors("Jack and Jane");
     ce.setStartEventDateTime(ISODateTime.parse("2007-12-03T10:15:30").toString());
     ce.setEndEventDateTime(ISODateTime.parse("2007-12-04T11:20:20").toString());
     ce.setDwcVerbatimCoordinates("26.089, 106.36");
@@ -129,8 +123,6 @@ public class CollectingEventRepositoryIT extends CollectionModuleBaseIT {
     assertNotNull(result.getCreatedBy());
     assertEquals(ce.getAttachment().get(0).getId(), result.getAttachment().get(0).getId());
     assertEquals(ce.getCollectors().get(0).getId(), result.getCollectors().get(0).getId());
-    assertEquals("Jack and Jane", result.getVerbatimCollectors());
-    assertEquals(ce.getCollectorGroupUuid(), result.getCollectorGroupUuid());
     assertEquals(dwcRecordedBy, result.getDwcRecordedBy());                   
     assertEquals(dwcVerbatimLocality, result.getDwcVerbatimLocality());
     assertEquals(dwcGeoreferenceSources, result.getDwcGeoreferenceSources());


### PR DESCRIPTION
- Remove from migration, repository , entity , dto and tests