### PR TITLE
21849 bug linking geos to events

### DIFF
--- a/src/main/java/ca/gc/aafc/collection/api/dto/CollectingEventDto.java
+++ b/src/main/java/ca/gc/aafc/collection/api/dto/CollectingEventDto.java
@@ -9,6 +9,7 @@ import java.util.function.Supplier;
 
 import javax.annotation.Nullable;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
 import org.apache.commons.lang3.StringUtils;
 
 import ca.gc.aafc.collection.api.datetime.ISODateTime;
@@ -45,7 +46,8 @@ public class CollectingEventDto {
   private OffsetDateTime createdOn;
 
   @JsonApiRelation
-  private List<GeoReferenceAssertionDto> geoReferenceAssertions;  
+  @JsonInclude(JsonInclude.Include.NON_EMPTY)
+  private List<GeoReferenceAssertionDto> geoReferenceAssertions = new ArrayList<>();
 
   private String dwcVerbatimCoordinates;
   private String dwcRecordedBy;

--- a/src/main/java/ca/gc/aafc/collection/api/service/CollectingEventService.java
+++ b/src/main/java/ca/gc/aafc/collection/api/service/CollectingEventService.java
@@ -1,7 +1,10 @@
 package ca.gc.aafc.collection.api.service;
 
+import java.util.List;
 import java.util.UUID;
 
+import ca.gc.aafc.collection.api.entities.GeoReferenceAssertion;
+import org.apache.commons.collections.CollectionUtils;
 import org.springframework.stereotype.Service;
 
 import ca.gc.aafc.collection.api.entities.CollectingEvent;
@@ -12,13 +15,26 @@ import lombok.NonNull;
 @Service
 public class CollectingEventService extends DefaultDinaService<CollectingEvent> {
 
-    public CollectingEventService(@NonNull BaseDAO baseDAO) {
-        super(baseDAO);
-    }
+  public CollectingEventService(@NonNull BaseDAO baseDAO) {
+    super(baseDAO);
+  }
 
-    @Override
-    protected void preCreate(CollectingEvent entity) {    
-      entity.setUuid(UUID.randomUUID());    
+  @Override
+  protected void preCreate(CollectingEvent entity) {
+    entity.setUuid(UUID.randomUUID());
+    linkAssertions(entity);
+  }
+
+  @Override
+  public void preUpdate(CollectingEvent entity) {
+    linkAssertions(entity);
+  }
+
+  private void linkAssertions(CollectingEvent entity) {
+    List<GeoReferenceAssertion> geos = entity.getGeoReferenceAssertions();
+    if (CollectionUtils.isNotEmpty(geos)) {
+      geos.forEach(geoReferenceAssertion -> geoReferenceAssertion.setCollectingEvent(entity));
     }
-    
+  }
+
 }


### PR DESCRIPTION
use service to cascade linking of relations

Foreign key is on the Geo side. Typically you would probably submit the Geo with the Event, this addition to the service will allow you to submit the Event with the Geo.

We should be supporting this as JSON spec requires it.