### PR TITLE
Feedback 22180

### DIFF
--- a/src/main/java/ca/gc/aafc/collection/api/dto/CollectingEventDto.java
+++ b/src/main/java/ca/gc/aafc/collection/api/dto/CollectingEventDto.java
@@ -1,5 +1,22 @@
 package ca.gc.aafc.collection.api.dto;
 
+import java.time.OffsetDateTime;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+import java.util.function.Consumer;
+import java.util.function.Supplier;
+
+import javax.annotation.Nullable;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+
+import org.apache.commons.lang3.StringUtils;
+import org.javers.core.metamodel.annotation.DiffIgnore;
+import org.javers.core.metamodel.annotation.Id;
+import org.javers.core.metamodel.annotation.PropertyName;
+import org.javers.core.metamodel.annotation.TypeName;
+
 import ca.gc.aafc.collection.api.datetime.ISODateTime;
 import ca.gc.aafc.collection.api.entities.CollectingEvent;
 import ca.gc.aafc.collection.api.entities.CollectingEvent.GeoreferenceVerificationStatus;
@@ -10,26 +27,12 @@ import ca.gc.aafc.dina.mapper.CustomFieldAdapter;
 import ca.gc.aafc.dina.mapper.DinaFieldAdapter;
 import ca.gc.aafc.dina.mapper.IgnoreDinaMapping;
 import ca.gc.aafc.dina.repository.meta.JsonApiExternalRelation;
-import com.fasterxml.jackson.annotation.JsonInclude;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import io.crnk.core.resource.annotations.JsonApiId;
 import io.crnk.core.resource.annotations.JsonApiRelation;
 import io.crnk.core.resource.annotations.JsonApiResource;
 import lombok.Data;
 import lombok.NoArgsConstructor;
-import org.apache.commons.lang3.StringUtils;
-import org.javers.core.metamodel.annotation.DiffIgnore;
-import org.javers.core.metamodel.annotation.Id;
-import org.javers.core.metamodel.annotation.PropertyName;
-import org.javers.core.metamodel.annotation.TypeName;
-
-import javax.annotation.Nullable;
-import java.time.OffsetDateTime;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.UUID;
-import java.util.function.Consumer;
-import java.util.function.Supplier;
 
 @RelatedEntity(CollectingEvent.class)
 @CustomFieldAdapter(adapters = {
@@ -55,6 +58,7 @@ public class CollectingEventDto {
 
   @JsonApiRelation
   @JsonInclude(JsonInclude.Include.NON_EMPTY)
+  @DiffIgnore
   private List<GeoreferenceAssertionDto> geoReferenceAssertions = new ArrayList<>();
 
   private String dwcVerbatimCoordinates;

--- a/src/main/java/ca/gc/aafc/collection/api/dto/GeoreferenceAssertionDto.java
+++ b/src/main/java/ca/gc/aafc/collection/api/dto/GeoreferenceAssertionDto.java
@@ -1,5 +1,16 @@
 package ca.gc.aafc.collection.api.dto;
 
+import java.time.LocalDate;
+import java.time.OffsetDateTime;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+
+import org.javers.core.metamodel.annotation.Id;
+import org.javers.core.metamodel.annotation.PropertyName;
+import org.javers.core.metamodel.annotation.ShallowReference;
+import org.javers.core.metamodel.annotation.TypeName;
+
 import ca.gc.aafc.collection.api.entities.GeoreferenceAssertion;
 import ca.gc.aafc.dina.dto.ExternalRelationDto;
 import ca.gc.aafc.dina.dto.RelatedEntity;
@@ -9,15 +20,6 @@ import io.crnk.core.resource.annotations.JsonApiId;
 import io.crnk.core.resource.annotations.JsonApiRelation;
 import io.crnk.core.resource.annotations.JsonApiResource;
 import lombok.Data;
-import org.javers.core.metamodel.annotation.Id;
-import org.javers.core.metamodel.annotation.PropertyName;
-import org.javers.core.metamodel.annotation.TypeName;
-
-import java.time.LocalDate;
-import java.time.OffsetDateTime;
-import java.util.List;
-import java.util.UUID;
-import java.util.ArrayList;
 
 @RelatedEntity(GeoreferenceAssertion.class)
 @SuppressFBWarnings({"EI_EXPOSE_REP", "EI_EXPOSE_REP2"})
@@ -51,5 +53,6 @@ public class GeoreferenceAssertionDto {
   private List<ExternalRelationDto> georeferencedBy = new ArrayList<>();
 
   @JsonApiRelation
+  @ShallowReference
   private CollectingEventDto collectingEvent;
 }

--- a/src/main/java/ca/gc/aafc/collection/api/entities/GeographicPlaceNameSourceDetail.java
+++ b/src/main/java/ca/gc/aafc/collection/api/entities/GeographicPlaceNameSourceDetail.java
@@ -6,8 +6,11 @@ import lombok.Data;
 import java.net.URL;
 import java.time.OffsetDateTime;
 
+import org.javers.core.metamodel.annotation.Value;
+
 @Data
 @Builder
+@Value // This class is considered a "value" belonging to a CollectingEventDto.
 public class GeographicPlaceNameSourceDetail {
   private String sourceID;
   private String sourceIdType;

--- a/src/main/java/ca/gc/aafc/collection/api/repository/GeoreferenceAssertionRepository.java
+++ b/src/main/java/ca/gc/aafc/collection/api/repository/GeoreferenceAssertionRepository.java
@@ -1,5 +1,10 @@
 package ca.gc.aafc.collection.api.repository;
 
+import java.util.Optional;
+
+import org.springframework.boot.info.BuildProperties;
+import org.springframework.stereotype.Repository;
+
 import ca.gc.aafc.collection.api.dto.GeoreferenceAssertionDto;
 import ca.gc.aafc.collection.api.entities.GeoreferenceAssertion;
 import ca.gc.aafc.collection.api.service.GeoReferenceAssertionService;
@@ -7,11 +12,8 @@ import ca.gc.aafc.dina.mapper.DinaMapper;
 import ca.gc.aafc.dina.repository.DinaRepository;
 import ca.gc.aafc.dina.repository.external.ExternalResourceProvider;
 import ca.gc.aafc.dina.security.DinaAuthenticatedUser;
+import ca.gc.aafc.dina.service.AuditService;
 import lombok.NonNull;
-import org.springframework.boot.info.BuildProperties;
-import org.springframework.stereotype.Repository;
-
-import java.util.Optional;
 
 @Repository
 public class GeoreferenceAssertionRepository extends DinaRepository<GeoreferenceAssertionDto, GeoreferenceAssertion> {
@@ -22,12 +24,13 @@ public class GeoreferenceAssertionRepository extends DinaRepository<Georeference
     @NonNull GeoReferenceAssertionService dinaService,    
     @NonNull BuildProperties props,
     Optional<DinaAuthenticatedUser> authenticatedUser,
-    @NonNull ExternalResourceProvider externalResourceProvider
+    @NonNull ExternalResourceProvider externalResourceProvider,
+    @NonNull AuditService auditService
   ) {
     super(
       dinaService,
       Optional.empty(),
-      Optional.empty(),
+      Optional.of(auditService),
       new DinaMapper<>(GeoreferenceAssertionDto.class),
       GeoreferenceAssertionDto.class,
       GeoreferenceAssertion.class,


### PR DESCRIPTION
-Made GeoReferenceAssertionDto auditable.
-Added DiffIgnore to CollectingEventDto#geoReferenceAssertions field.
-Added @Value annotation to GeographicPlaceNameSourceDetail so it gets embedded in the Collecting Event audit record.