### PR TITLE
22322 rename to Other geo assertions

### DIFF
--- a/src/main/java/ca/gc/aafc/collection/api/dto/CollectingEventDto.java
+++ b/src/main/java/ca/gc/aafc/collection/api/dto/CollectingEventDto.java
@@ -58,7 +58,7 @@ public class CollectingEventDto {
   @JsonApiRelation
   @JsonInclude(JsonInclude.Include.NON_EMPTY)
   @DiffIgnore
-  private List<GeoreferenceAssertionDto> geoReferenceAssertions = new ArrayList<>();
+  private List<GeoreferenceAssertionDto> otherGeoReferenceAssertions = new ArrayList<>();
 
   @JsonApiRelation
   private GeoreferenceAssertionDto primaryGeoreferenceAssertion;

--- a/src/main/java/ca/gc/aafc/collection/api/entities/CollectingEvent.java
+++ b/src/main/java/ca/gc/aafc/collection/api/entities/CollectingEvent.java
@@ -86,7 +86,7 @@ public class CollectingEvent implements DinaEntity {
       mappedBy = "collectingEvent",
       cascade = {CascadeType.PERSIST, CascadeType.MERGE, CascadeType.REMOVE}
       )
-  private List<GeoreferenceAssertion> geoReferenceAssertions;
+  private List<GeoreferenceAssertion> otherGeoReferenceAssertions;
 
   @OneToOne(fetch = FetchType.LAZY, cascade = CascadeType.ALL)
   @ToString.Exclude

--- a/src/main/java/ca/gc/aafc/collection/api/service/CollectingEventService.java
+++ b/src/main/java/ca/gc/aafc/collection/api/service/CollectingEventService.java
@@ -44,7 +44,7 @@ public class CollectingEventService extends DefaultDinaService<CollectingEvent> 
   }
 
   private static void linkAssertions(CollectingEvent entity) {
-    List<GeoreferenceAssertion> geos = entity.getGeoReferenceAssertions();
+    List<GeoreferenceAssertion> geos = entity.getOtherGeoReferenceAssertions();
     if (CollectionUtils.isNotEmpty(geos)) {
       geos.forEach(geoReferenceAssertion -> geoReferenceAssertion.setCollectingEvent(entity));
     }

--- a/src/main/java/ca/gc/aafc/collection/api/validation/CollectingEventValidator.java
+++ b/src/main/java/ca/gc/aafc/collection/api/validation/CollectingEventValidator.java
@@ -28,7 +28,7 @@ public class CollectingEventValidator implements Validator {
     @Override
     public void validate(Object target, Errors errors) {
       CollectingEvent collectingEvent = (CollectingEvent) target;
-      int assertionsSize = Optional.ofNullable(collectingEvent.getGeoReferenceAssertions())
+      int assertionsSize = Optional.ofNullable(collectingEvent.getOtherGeoReferenceAssertions())
       .map(List::size).orElse(0);
       if ((collectingEvent.getStartEventDateTime() == null && collectingEvent.getEndEventDateTime() != null)
             || (collectingEvent.getEndEventDateTime() != null
@@ -42,7 +42,7 @@ public class CollectingEventValidator implements Validator {
           null, LocaleContextHolder.getLocale());
           errors.rejectValue("primaryGeoreferenceAssertion", "collectingEvent.primaryGeoreferenceAssertion.null", errorMessage);
       } 
-      if (assertionsSize > 0 && collectingEvent.getGeoReferenceAssertions().contains(collectingEvent.getPrimaryGeoreferenceAssertion())) {
+      if (assertionsSize > 0 && collectingEvent.getOtherGeoReferenceAssertions().contains(collectingEvent.getPrimaryGeoreferenceAssertion())) {
           String errorMessage = messageSource.getMessage("collectingEvent.primaryGeoreferenceAssertion.inList",
           null, LocaleContextHolder.getLocale());
           errors.rejectValue("primaryGeoreferenceAssertion", "collectingEvent.primaryGeoreferenceAssertion.inList", errorMessage);

--- a/src/test/java/ca/gc/aafc/collection/api/entities/CollectingEventCRUDIT.java
+++ b/src/test/java/ca/gc/aafc/collection/api/entities/CollectingEventCRUDIT.java
@@ -11,7 +11,6 @@ import org.junit.jupiter.api.Test;
 import javax.inject.Inject;
 import java.net.URL;
 import java.time.LocalDateTime;
-import java.time.OffsetDateTime;
 import java.util.Collections;
 import java.util.UUID;
 
@@ -60,7 +59,7 @@ public class CollectingEventCRUDIT extends CollectionModuleBaseIT {
     collectingEvent.setUuid(UUID.randomUUID());
     geoReferenceAssertion.setUuid(UUID.randomUUID());
     dbService.save(geoReferenceAssertion,false);
-    collectingEvent.setGeoReferenceAssertions(Collections.singletonList(geoReferenceAssertion));
+    collectingEvent.setOtherGeoReferenceAssertions(Collections.singletonList(geoReferenceAssertion));
     collectingEvent.setPrimaryGeoreferenceAssertion(geoReferenceAssertion);
     assertNull(collectingEvent.getId());
     dbService.save(collectingEvent, false);
@@ -73,7 +72,7 @@ public class CollectingEventCRUDIT extends CollectionModuleBaseIT {
     geoReferenceAssertion.setUuid(UUID.randomUUID());
     dbService.save(geoReferenceAssertion,false);
     CollectingEvent collectingEvent = CollectingEventFactory.newCollectingEvent()
-        .geoReferenceAssertions(Collections.singletonList((geoReferenceAssertion)))
+        .otherGeoReferenceAssertions(Collections.singletonList((geoReferenceAssertion)))
         .primaryGeoreferenceAssertion(geoReferenceAssertion)        
         .startEventDateTime(testDateTime)
         .startEventDateTimePrecision((byte) 8)
@@ -104,11 +103,11 @@ public class CollectingEventCRUDIT extends CollectionModuleBaseIT {
     assertEquals(dwcRecordedBy, fetchedCollectingEvent.getDwcRecordedBy());
     assertEquals(
       geoReferenceAssertion.getId(),
-      fetchedCollectingEvent.getGeoReferenceAssertions().iterator().next().getId());    
+      fetchedCollectingEvent.getOtherGeoReferenceAssertions().iterator().next().getId());
     assertEquals(geoReferenceAssertion.getId(), fetchedCollectingEvent.getPrimaryGeoreferenceAssertion().getId());
     assertEquals(
       12.123456,
-      fetchedCollectingEvent.getGeoReferenceAssertions().iterator().next().getDwcDecimalLatitude());    
+      fetchedCollectingEvent.getOtherGeoReferenceAssertions().iterator().next().getDwcDecimalLatitude());
     assertNotNull(fetchedCollectingEvent.getCreatedOn());
     assertEquals(dwcVerbatimLocality, fetchedCollectingEvent.getDwcVerbatimLocality());
     assertEquals(dwcVerbatimLatitude, fetchedCollectingEvent.getDwcVerbatimLatitude());

--- a/src/test/java/ca/gc/aafc/collection/api/repository/CollectingEventRepositoryIT.java
+++ b/src/test/java/ca/gc/aafc/collection/api/repository/CollectingEventRepositoryIT.java
@@ -11,7 +11,6 @@ import ca.gc.aafc.collection.api.service.CollectingEventService;
 import ca.gc.aafc.collection.api.testsupport.factories.CollectingEventFactory;
 import ca.gc.aafc.collection.api.testsupport.factories.GeoreferenceAssertionFactory;
 import ca.gc.aafc.dina.dto.ExternalRelationDto;
-import ca.gc.aafc.dina.mapper.DinaMapper;
 import ca.gc.aafc.dina.testsupport.DatabaseSupportService;
 import ca.gc.aafc.dina.testsupport.security.WithMockKeycloakUser;
 import io.crnk.core.queryspec.FilterOperator;
@@ -19,7 +18,6 @@ import io.crnk.core.queryspec.IncludeRelationSpec;
 import io.crnk.core.queryspec.PathSpec;
 import io.crnk.core.queryspec.QuerySpec;
 import lombok.SneakyThrows;
-import org.apache.tomcat.jni.Local;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -147,7 +145,7 @@ public class CollectingEventRepositoryIT extends CollectionModuleBaseIT {
       .geographicPlaceNameSource(geographicPlaceNameSource)
       .geographicPlaceNameSourceDetail(geographicPlaceNameSourceDetail)
       .build();
-    testCollectingEvent.setGeoReferenceAssertions(Collections.singletonList(geoReferenceAssertion));
+    testCollectingEvent.setOtherGeoReferenceAssertions(Collections.singletonList(geoReferenceAssertion));
     testCollectingEvent.setPrimaryGeoreferenceAssertion(primaryGeoReferenceAssertion);
 
     collectingEventService.create(testCollectingEvent);
@@ -170,10 +168,10 @@ public class CollectingEventRepositoryIT extends CollectionModuleBaseIT {
   @Test
   public void updateCollectingEvent_setPrimaryAssertionToOneInList_throwsIllegalArgumentException() {
     List<GeoreferenceAssertion> georef = new ArrayList<>();
-    georef.add(testCollectingEvent.getGeoReferenceAssertions().iterator().next());
+    georef.add(testCollectingEvent.getOtherGeoReferenceAssertions().iterator().next());
     georef.add(geoReferenceAssertionA);
     georef.add(geoReferenceAssertionB);
-    testCollectingEvent.setGeoReferenceAssertions(georef);
+    testCollectingEvent.setOtherGeoReferenceAssertions(georef);
     testCollectingEvent.setPrimaryGeoreferenceAssertion(geoReferenceAssertionA);
     IllegalArgumentException exception = 
       assertThrows(IllegalArgumentException.class, () -> {
@@ -189,13 +187,13 @@ public class CollectingEventRepositoryIT extends CollectionModuleBaseIT {
   @Test
   public void updateCollectingEvent_changePrimaryGeoreferenceAssertion() {
     List<GeoreferenceAssertion> georef = new ArrayList<>();
-    georef.add(testCollectingEvent.getGeoReferenceAssertions().iterator().next());
+    georef.add(testCollectingEvent.getOtherGeoReferenceAssertions().iterator().next());
     georef.add(primaryGeoReferenceAssertion);
     georef.add(geoReferenceAssertionB);
-    testCollectingEvent.setGeoReferenceAssertions(georef);
+    testCollectingEvent.setOtherGeoReferenceAssertions(georef);
     testCollectingEvent.setPrimaryGeoreferenceAssertion(geoReferenceAssertionA);
     collectingEventService.update(testCollectingEvent);
-    assertEquals(testCollectingEvent.getGeoReferenceAssertions().size(), 3);
+    assertEquals(testCollectingEvent.getOtherGeoReferenceAssertions().size(), 3);
     assertEquals(testCollectingEvent.getPrimaryGeoreferenceAssertion().getDwcDecimalLatitude(), geoReferenceAssertionA.getDwcDecimalLatitude());
     assertEquals(testCollectingEvent.getPrimaryGeoreferenceAssertion().getDwcDecimalLongitude(), geoReferenceAssertionA.getDwcDecimalLongitude());
   }
@@ -230,11 +228,11 @@ public class CollectingEventRepositoryIT extends CollectionModuleBaseIT {
     
     assertEquals(
       12.123456,
-      collectingEventDto.getGeoReferenceAssertions().iterator().next().getDwcDecimalLatitude());    
+      collectingEventDto.getOtherGeoReferenceAssertions().iterator().next().getDwcDecimalLatitude());
 
     assertEquals(
       testGeoreferencedDate,
-      collectingEventDto.getGeoReferenceAssertions().iterator().next().getDwcGeoreferencedDate());          
+      collectingEventDto.getOtherGeoReferenceAssertions().iterator().next().getDwcGeoreferencedDate());
 
     assertEquals("26.089, 106.36", collectingEventDto.getDwcVerbatimCoordinates());
     assertEquals(dwcRecordedBy, collectingEventDto.getDwcRecordedBy());
@@ -337,7 +335,7 @@ public class CollectingEventRepositoryIT extends CollectionModuleBaseIT {
     geoRef.setDwcCoordinateUncertaintyInMeters(10);
     GeoreferenceAssertionDto dto = geoReferenceAssertionRepository.create(geoRef);
     GeoreferenceAssertionDto primaryDto = geoReferenceAssertionRepository.create(primaryGeoRef);
-    ce.setGeoReferenceAssertions(Collections.singletonList(dto));
+    ce.setOtherGeoReferenceAssertions(Collections.singletonList(dto));
     ce.setGroup("aafc");
     ce.setStartEventDateTime(ISODateTime.parse(startDateTime).toString());
     ce.setEndEventDateTime(ISODateTime.parse(endDateTime).toString());

--- a/src/test/java/ca/gc/aafc/collection/api/repository/CollectingEventRepositoryIT.java
+++ b/src/test/java/ca/gc/aafc/collection/api/repository/CollectingEventRepositoryIT.java
@@ -204,7 +204,7 @@ public class CollectingEventRepositoryIT extends CollectionModuleBaseIT {
     QuerySpec querySpec = new QuerySpec(CollectingEventDto.class);
     QuerySpec geoSpec = new QuerySpec(GeoreferenceAssertionDto.class);
 
-    List<IncludeRelationSpec> includeRelationSpec = Stream.of("geoReferenceAssertions")
+    List<IncludeRelationSpec> includeRelationSpec = Stream.of("otherGeoReferenceAssertions")
         .map(Arrays::asList)
         .map(IncludeRelationSpec::new)
         .collect(Collectors.toList());


### PR DESCRIPTION
rename field to otherGeoReferenceAssertions

example post
```
{
	"data": {
		"type": "collecting-event",
		"attributes": {
			...
		},
		"relationships": {
			"primaryGeoreferenceAssertion": {
				"data": {
					"type": "georeference-assertion",
					"id": "9fc17b30-f1fe-4ae4-bd57-3f3eddb75151"
				}
			},
			"otherGeoReferenceAssertions": {
				"data": [
					{
						"type": "georeference-assertion",
						"id": "19be15fb-e0e4-4197-aa96-cb7e1ff50cd0"
					}
				]
			}
		}
	}
}
```