### PR TITLE
23201 detached assertion thrown

### DIFF
--- a/src/main/java/ca/gc/aafc/collection/api/service/CollectingEventService.java
+++ b/src/main/java/ca/gc/aafc/collection/api/service/CollectingEventService.java
@@ -66,7 +66,15 @@ public class CollectingEventService extends DefaultDinaService<CollectingEvent> 
   public void validateBusinessRules(CollectingEvent entity) {
     applyBusinessRule(entity, collectingEventValidator);
     validateAssertions(entity);
+
+    List<GeoreferenceAssertion> incomingAssertions = entity.getGeoReferenceAssertions();
+    entity.setGeoReferenceAssertions(null); // Set null due to flushing mechanics with validateManagedAttribute
+
     validateManagedAttribute(entity);
+
+    if (CollectionUtils.isNotEmpty(incomingAssertions)) {
+      entity.setGeoReferenceAssertions(incomingAssertions);
+    }
   }
 
   private void resolveIncomingAssertion(CollectingEvent entity) {


### PR DESCRIPTION
prevent detached assertion thrown during flush from validateManagedAttribute

collection-api_1  | Caused by: org.hibernate.PersistentObjectException: detached entity passed to persist: ca.gc.aafc.collection.api.entities.GeoreferenceAssertion
collection-api_1  | 	at org.hibernate.event.internal.DefaultPersistEventListener.onPersist(DefaultPersistEventListener.java:120) ~[hibernate-core-5.4.31.Final.jar!/:5.4.31.Final]
collection-api_1  | 	at org.hibernate.event.service.internal.EventListenerGroupImpl.fireEventOnEachListener(EventListenerGroupImpl.java:104) ~[hibernate-core-5.4.31.Final.jar!/:5.4.31.Final]
collection-api_1  | 	at org.hibernate.internal.SessionImpl.persistOnFlush(SessionImpl.java:765) ~[hibernate-core-5.4.31.Final.jar!/:5.4.31.Final]
collection-api_1  | 	at org.hibernate.engine.spi.CascadingActions$8.cascade(CascadingActions.java:341) ~[hibernate-core-5.4.31.Final.jar!/:5.4.31.Final]
collection-api_1  | 	at org.hibernate.engine.internal.Cascade.cascadeToOne(Cascade.java:499) ~[hibernate-core-5.4.31.Final.jar!/:5.4.31.Final]
collection-api_1  | 	at org.hibernate.engine.internal.Cascade.cascadeAssociation(Cascade.java:423) ~[hibernate-core-5.4.31.Final.jar!/:5.4.31.Final]
collection-api_1  | 	at org.hibernate.engine.internal.Cascade.cascadeProperty(Cascade.java:220) ~[hibernate-core-5.4.31.Final.jar!/:5.4.31.Final]
collection-api_1  | 	at org.hibernate.engine.internal.Cascade.cascadeCollectionElements(Cascade.java:532) ~[hibernate-core-5.4.31.Final.jar!/:5.4.31.Final]
collection-api_1  | 	at org.hibernate.engine.internal.Cascade.cascadeCollection(Cascade.java:463) ~[hibernate-core-5.4.31.Final.jar!/:5.4.31.Final]
collection-api_1  | 	at org.hibernate.engine.internal.Cascade.cascadeAssociation(Cascade.java:426) ~[hibernate-core-5.4.31.Final.jar!/:5.4.31.Final]
collection-api_1  | 	at org.hibernate.engine.internal.Cascade.cascadeProperty(Cascade.java:220) ~[hibernate-core-5.4.31.Final.jar!/:5.4.31.Final]
collection-api_1  | 	at org.hibernate.engine.internal.Cascade.cascade(Cascade.java:153) ~[hibernate-core-5.4.31.Final.jar!/:5.4.31.Final]
collection-api_1  | 	at org.hibernate.event.internal.AbstractFlushingEventListener.cascadeOnFlush(AbstractFlushingEventListener.java:159) ~[hibernate-core-5.4.31.Final.jar!/:5.4.31.Final]
collection-api_1  | 	at org.hibernate.event.internal.AbstractFlushingEventListener.prepareEntityFlushes(AbstractFlushingEventListener.java:149) ~[hibernate-core-5.4.31.Final.jar!/:5.4.31.Final]
collection-api_1  | 	at org.hibernate.event.internal.AbstractFlushingEventListener.flushEverythingToExecutions(AbstractFlushingEventListener.java:82) ~[hibernate-core-5.4.31.Final.jar!/:5.4.31.Final]
collection-api_1  | 	at org.hibernate.event.internal.DefaultAutoFlushEventListener.onAutoFlush(DefaultAutoFlushEventListener.java:50) ~[hibernate-core-5.4.31.Final.jar!/:5.4.31.Final]
collection-api_1  | 	at org.hibernate.event.service.internal.EventListenerGroupImpl.fireEventOnEachListener(EventListenerGroupImpl.java:93) ~[hibernate-core-5.4.31.Final.jar!/:5.4.31.Final]
collection-api_1  | 	at org.hibernate.internal.SessionImpl.autoFlushIfRequired(SessionImpl.java:1327) ~[hibernate-core-5.4.31.Final.jar!/:5.4.31.Final]
collection-api_1  | 	at org.hibernate.internal.SessionImpl.list(SessionImpl.java:1407) ~[hibernate-core-5.4.31.Final.jar!/:5.4.31.Final]
collection-api_1  | 	at org.hibernate.query.internal.AbstractProducedQuery.doList(AbstractProducedQuery.java:1636) ~[hibernate-core-5.4.31.Final.jar!/:5.4.31.Final]
collection-api_1  | 	at org.hibernate.query.internal.AbstractProducedQuery.list(AbstractProducedQuery.java:1604) ~[hibernate-core-5.4.31.Final.jar!/:5.4.31.Final]
collection-api_1  | 	at org.hibernate.query.Query.getResultList(Query.java:165) ~[hibernate-core-5.4.31.Final.jar!/:5.4.31.Final]
collection-api_1  | 	at org.hibernate.query.criteria.internal.compile.CriteriaQueryTypeQueryAdapter.getResultList(CriteriaQueryTypeQueryAdapter.java:76) ~[hibernate-core-5.4.31.Final.jar!/:5.4.31.Final]
collection-api_1  | 	at ca.gc.aafc.dina.jpa.BaseDAO.resultListFromCriteria(BaseDAO.java:313) ~[dina-base-api-0.58.jar!/:0.58]
collection-api_1  | 	at ca.gc.aafc.dina.service.DefaultDinaService.findAll(DefaultDinaService.java:138) ~[dina-base-api-0.58.jar!/:0.58]
collection-api_1  | 	at ca.gc.aafc.dina.service.DefaultDinaService.findAll(DefaultDinaService.java:108) ~[dina-base-api-0.58.jar!/:0.58]
collection-api_1  | 	at ca.gc.aafc.dina.service.ManagedAttributeService.findAttributesForKeys(ManagedAttributeService.java:53) ~[dina-base-api-0.58.jar!/:0.58]