### PR TITLE
24349_immutable_storage_unit_exposes_uuid

### DIFF
--- a/src/main/java/ca/gc/aafc/collection/api/dto/ImmutableStorageUnitDto.java
+++ b/src/main/java/ca/gc/aafc/collection/api/dto/ImmutableStorageUnitDto.java
@@ -2,6 +2,8 @@ package ca.gc.aafc.collection.api.dto;
 
 import ca.gc.aafc.collection.api.entities.ImmutableStorageUnit;
 import ca.gc.aafc.dina.dto.RelatedEntity;
+import com.fasterxml.jackson.annotation.JsonAlias;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import io.crnk.core.resource.annotations.JsonApiId;
 import lombok.Data;
 
@@ -13,6 +15,8 @@ import java.util.UUID;
 public class ImmutableStorageUnitDto {
 
   @JsonApiId
+  @JsonProperty("id")
+  @JsonAlias("uuid")
   private UUID uuid;
 
   private OffsetDateTime createdOn;

--- a/src/main/java/ca/gc/aafc/collection/api/dto/ImmutableStorageUnitDto.java
+++ b/src/main/java/ca/gc/aafc/collection/api/dto/ImmutableStorageUnitDto.java
@@ -2,10 +2,12 @@ package ca.gc.aafc.collection.api.dto;
 
 import ca.gc.aafc.collection.api.entities.ImmutableStorageUnit;
 import ca.gc.aafc.dina.dto.RelatedEntity;
-import com.fasterxml.jackson.annotation.JsonAlias;
-import com.fasterxml.jackson.annotation.JsonProperty;
+import ca.gc.aafc.dina.mapper.IgnoreDinaMapping;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import io.crnk.core.resource.annotations.JsonApiId;
+import lombok.AccessLevel;
 import lombok.Data;
+import lombok.Setter;
 
 import java.time.OffsetDateTime;
 import java.util.UUID;
@@ -15,9 +17,12 @@ import java.util.UUID;
 public class ImmutableStorageUnitDto {
 
   @JsonApiId
-  @JsonProperty("id")
-  @JsonAlias("uuid")
+  @JsonIgnore
   private UUID uuid;
+
+  @Setter(AccessLevel.NONE)
+  @IgnoreDinaMapping
+  private UUID id;
 
   private OffsetDateTime createdOn;
   private String createdBy;
@@ -25,4 +30,9 @@ public class ImmutableStorageUnitDto {
   private String group;
 
   private String name;
+
+  public void setUuid(UUID uuid) {
+    this.uuid = uuid;
+    this.id = uuid;
+  }
 }

--- a/src/test/java/ca/gc/aafc/collection/api/rest/StorageUnitRestIT.java
+++ b/src/test/java/ca/gc/aafc/collection/api/rest/StorageUnitRestIT.java
@@ -48,14 +48,14 @@ public class StorageUnitRestIT extends BaseRestAssuredTest {
       .body("data.attributes.group", Matchers.is(unit.getGroup()))
       .body("data.attributes.createdBy", Matchers.notNullValue())
       .body("data.attributes.createdOn", Matchers.notNullValue())
-      .body("data.attributes.storageUnitChildren[0].uuid", Matchers.is(childId))
+      .body("data.attributes.storageUnitChildren[0].id", Matchers.is(childId))
       .body("data.relationships.parentStorageUnit.data.id", Matchers.is(parentId))
       .body("data.relationships.storageUnitType.data.id", Matchers.is(unitTypeId));
     findUnit(childId)
       .body("data.attributes.storageUnitChildren", Matchers.empty())
       .body("data.relationships.parentStorageUnit.data.id", Matchers.is(unitId));
     findUnit(parentId)
-      .body("data.attributes.storageUnitChildren[0].uuid", Matchers.is(unitId))
+      .body("data.attributes.storageUnitChildren[0].id", Matchers.is(unitId))
       .body("data.relationships.parentStorageUnit.data", Matchers.nullValue());
   }
 


### PR DESCRIPTION
Combine:
  @JsonProperty("id") allows serialization to change the field name
  @JsonAlias("uuid") prevents crnk from breaking