### PR TITLE
Allow user-provided uuid on organism

### DIFF
--- a/src/main/java/ca/gc/aafc/collection/api/service/OrganismService.java
+++ b/src/main/java/ca/gc/aafc/collection/api/service/OrganismService.java
@@ -29,7 +29,11 @@ public class OrganismService extends DefaultDinaService<Organism> {
 
   @Override
   protected void preCreate(Organism entity) {
-    entity.setUuid(UUID.randomUUID());
+    // allow user provided UUID
+    if(entity.getUuid() == null) {
+      entity.setUuid(UUID.randomUUID());
+    }
+
     setupDeterminations(entity);
   }
 

--- a/src/test/java/ca/gc/aafc/collection/api/repository/CollectingEventRepositoryIT.java
+++ b/src/test/java/ca/gc/aafc/collection/api/repository/CollectingEventRepositoryIT.java
@@ -146,9 +146,7 @@ public class CollectingEventRepositoryIT extends CollectionModuleBaseIT {
 
     QuerySpec querySpec = new QuerySpec(CollectingEventDto.class);
     CollectingEventDto refreshedCe = collectingEventRepository.findOne(myUUID, querySpec);
-
     assertNotNull(refreshedCe);
-
   }
 
   private void assertAssertion(

--- a/src/test/java/ca/gc/aafc/collection/api/repository/OrganismRepositoryIT.java
+++ b/src/test/java/ca/gc/aafc/collection/api/repository/OrganismRepositoryIT.java
@@ -1,6 +1,8 @@
 package ca.gc.aafc.collection.api.repository;
 
+import ca.gc.aafc.collection.api.dto.CollectingEventDto;
 import ca.gc.aafc.collection.api.dto.OrganismDto;
+import ca.gc.aafc.collection.api.testsupport.fixtures.CollectingEventTestFixture;
 import ca.gc.aafc.collection.api.testsupport.fixtures.DeterminationFixture;
 import ca.gc.aafc.collection.api.testsupport.fixtures.OrganismTestFixture;
 import ca.gc.aafc.dina.testsupport.security.WithMockKeycloakUser;
@@ -28,6 +30,19 @@ public class OrganismRepositoryIT extends BaseRepositoryIT {
         new QuerySpec(OrganismDto.class));
     assertNotNull(result.getCreatedBy());
     organismRepository.delete(organismUUID);
+  }
+
+  @WithMockKeycloakUser(groupRole = {OrganismTestFixture.GROUP + ":staff"})
+  @Test
+  public void create_withUserProvidedUUID_resourceCreatedWithProvidedUUID() throws MalformedURLException {
+    UUID myUUID = UUID.randomUUID();
+    OrganismDto organismDto = OrganismTestFixture.newOrganism(DeterminationFixture.newDetermination());
+    organismDto.setUuid(myUUID);
+    organismRepository.create(organismDto);
+
+    QuerySpec querySpec = new QuerySpec(OrganismDto.class);
+    OrganismDto refreshedCe = organismRepository.findOne(myUUID, querySpec);
+    assertNotNull(refreshedCe);
   }
 
 }


### PR DESCRIPTION
The organism service will now only generate a uuid in case none is provided.