### PR TITLE
Add agronomy ontology v1 extension

### DIFF
--- a/src/main/java/ca/gc/aafc/collection/api/CollectionExtensionConfiguration.java
+++ b/src/main/java/ca/gc/aafc/collection/api/CollectionExtensionConfiguration.java
@@ -16,6 +16,7 @@ import ca.gc.aafc.dina.property.YamlPropertyLoaderFactory;
 @PropertySource(value = "classpath:extension/cfia_ppc.yml", factory  = YamlPropertyLoaderFactory.class)
 @PropertySource(value = "classpath:extension/phac_rg.yml", factory  = YamlPropertyLoaderFactory.class)
 @PropertySource(value = "classpath:extension/phac_cl.yml", factory  = YamlPropertyLoaderFactory.class)
+@PropertySource(value = "classpath:extension/agronomy_ontology.yml", factory = YamlPropertyLoaderFactory.class)
 public class CollectionExtensionConfiguration {
 
   private final Map<String, Extension> extension;

--- a/src/main/resources/extension/agronomy_ontology.yml
+++ b/src/main/resources/extension/agronomy_ontology.yml
@@ -6,6 +6,7 @@ extension:
     fields:
     - key: "crop"
       name: "crop"
+      term: "http://purl.obolibrary.org/obo/AGRO_00000325"
       multilingualDescription.descriptions:
         - lang: en
           desc: "A crop is any cultivated plant, fungus, or alga that is harvested for food, clothing, livestock, fodder, biofuel, medicine, or other uses [hasDbXref: https://en.wikipedia.org/wiki/Crop]"
@@ -14,6 +15,7 @@ extension:
       dinaComponent: "MATERIAL_SAMPLE"
     - key: "grain_nitrogen_content"
       name: "grain nitrogen content"
+      term: "http://purl.obolibrary.org/obo/TO_0003068"
       multilingualDescription.descriptions:
         - lang: en
           desc: "A nitrogen content trait (TO:0020093) which is the amount of nitrogen (CHEBI:51143) in a caryopsis fruit (PO:0030104). [hasDbXref: TO:malaporte]"
@@ -22,6 +24,7 @@ extension:
       dinaComponent: "MATERIAL_SAMPLE"
     - key: "grain_phosphorus_content"
       name: "grain phosphorus content"
+      term: "http://purl.obolibrary.org/obo/TO_0003082"
       multilingualDescription.descriptions:
         - lang: en
           desc: "A phosphorus content trait (TO:0001024) which is the amount of phosphorus cation (CHEBI:33467) in a caryopsis fruit (PO:0030104). [hasDbXref: TO:malaporte]"
@@ -30,6 +33,7 @@ extension:
       dinaComponent: "MATERIAL_SAMPLE"
     - key: "1000_grain_weight"
       name: "1000-grain weight"
+      term: "http://purl.obolibrary.org/obo/TO_0000382"
       multilingualDescription.descriptions:
         - lang: en
           desc: "A grain weight (TO:0000919) which is the weight of a sample of 1000 grains (caryopsis fruit; PO:0030104), with the caryopsis hull (PO:0006000). [hasDbXref: Gramene:pankaj_jaiswal]"

--- a/src/main/resources/extension/agronomy_ontology.yml
+++ b/src/main/resources/extension/agronomy_ontology.yml
@@ -1,5 +1,5 @@
 extension:
-  agronomy_ontology:
+  agronomy_ontology_v1:
     name: "Agronomy Ontology"
     key: "agronomy_ontology_v1"
     version: "v1"

--- a/src/main/resources/extension/agronomy_ontology.yml
+++ b/src/main/resources/extension/agronomy_ontology.yml
@@ -1,0 +1,38 @@
+extension:
+  agronomy_ontology:
+    name: "Agronomy Ontology"
+    key: "agronomy_ontology_v1"
+    version: "v1"
+    fields:
+    - key: "crop"
+      name: "crop"
+      multilingualDescription.descriptions:
+        - lang: en
+          desc: "A crop is any cultivated plant, fungus, or alga that is harvested for food, clothing, livestock, fodder, biofuel, medicine, or other uses [hasDbXref: https://en.wikipedia.org/wiki/Crop]"
+        - lang: fr
+          desc: "Une culture est n'importe quel plante, champignon, ou algue cultivé qui est récolté pour la nourriture, les vêtements, le bétail, le fourrage, le biocarburant, la médecine, ou d'autres utilisations [hasDbXref: https://fr.wikipedia.org/wiki/Culture_(agriculture)]"
+      dinaComponent: "MATERIAL_SAMPLE"
+    - key: "grain_nitrogen_content"
+      name: "grain nitrogen content"
+      multilingualDescription.descriptions:
+        - lang: en
+          desc: "A nitrogen content trait (TO:0020093) which is the amount of nitrogen (CHEBI:51143) in a caryopsis fruit (PO:0030104). [hasDbXref: TO:malaporte]"
+        - lang: fr
+          desc: "Un trait de teneur en azote (TO:0020093) qui est la quantité d'azote (CHEBI:51143) dans un fruit caryopse (PO:0030104). [hasDbXref: TO:malaporte]"
+      dinaComponent: "MATERIAL_SAMPLE"
+    - key: "grain_phosphorus_content"
+      name: "grain phosphorus content"
+      multilingualDescription.descriptions:
+        - lang: en
+          desc: "A phosphorus content trait (TO:0001024) which is the amount of phosphorus cation (CHEBI:33467) in a caryopsis fruit (PO:0030104). [hasDbXref: TO:malaporte]"
+        - lang: fr
+          desc: "Un trait de teneur en phosphore (TO:0001024) qui est la quantité de phosphore cation (CHEBI:33467) dans un fruit caryopse (PO:0030104). [hasDbXref: TO:malaporte]"
+      dinaComponent: "MATERIAL_SAMPLE"
+    - key: "1000_grain_weight"
+      name: "1000-grain weight"
+      multilingualDescription.descriptions:
+        - lang: en
+          desc: "A grain weight (TO:0000919) which is the weight of a sample of 1000 grains (caryopsis fruit; PO:0030104), with the caryopsis hull (PO:0006000). [hasDbXref: Gramene:pankaj_jaiswal]"
+        - lang: fr
+          desc: "Un poids de grains (TO:0000919) qui est le poids d'un échantillon de mille grains (fruit de caryopse; PO:0030104), avec la cosse de caryopse (PO:0006000). [hasDbXref: Gramene:pankaj_jaiswal]"
+      dinaComponent: "MATERIAL_SAMPLE"

--- a/src/test/java/ca/gc/aafc/collection/api/ExtensionConfigurationTest.java
+++ b/src/test/java/ca/gc/aafc/collection/api/ExtensionConfigurationTest.java
@@ -49,4 +49,13 @@ public class ExtensionConfigurationTest extends CollectionModuleBaseIT {
     assertEquals("2022-02", cfiaPpc.getVersion());
   }
 
+  @Test
+  void getAgronomyOntology() {
+    Extension agronomyOntology = extensionConfiguration.getExtension().get("agronomy_ontology_v1");
+
+    assertNotNull(agronomyOntology);
+    assertEquals("Agronomy Ontology", agronomyOntology.getName());
+    assertEquals("agronomy_ontology_v1", agronomyOntology.getKey());
+    assertEquals("v1", agronomyOntology.getVersion());
+  }
 }

--- a/src/test/java/ca/gc/aafc/collection/api/repository/ExtensionRepositoryIT.java
+++ b/src/test/java/ca/gc/aafc/collection/api/repository/ExtensionRepositoryIT.java
@@ -45,6 +45,7 @@ public class ExtensionRepositoryIT extends CollectionModuleBaseIT {
         collectionExtensionConfiguration.getExtension().get("phac_human_rg"),
         collectionExtensionConfiguration.getExtension().get("phac_animal_rg"),
         collectionExtensionConfiguration.getExtension().get("phac_cl")
+        collectionExtensionConfiguration.getExtension().get("agronomy_ontology")
       ));
   }
   


### PR DESCRIPTION
Descriptions only include attributes that will be used for LTAE data.

Pull request now from dev fork (replacing pull request #388) and incorporating feedback from @cgendreau.