### PR TITLE
Support 31095 Add Unit to MIxS field extensions

### DIFF
--- a/src/main/resources/extension/mixsMicrobialv4.yml
+++ b/src/main/resources/extension/mixsMicrobialv4.yml
@@ -10,30 +10,35 @@ extension:
         - lang: en
           desc: "alkalinity, the ability of a solution to neutralize acids to the equivalence point\
         \ of carbonate or bicarbonate"
+      unit: "milliequivalent per liter"
       dinaComponent: "COLLECTING_EVENT"
     - key: "alkyl_diethers"
       name: "alkyl diethers"
       multilingualDescription.descriptions:
         - lang: en
           desc: "concentration of alkyl diethers "
+      unit: "mole per liter"
       dinaComponent: "COLLECTING_EVENT"
     - key: "aminopept_act"
       name: "aminopeptidase activity"
       multilingualDescription.descriptions:
         - lang: en
           desc: "measurement of aminopeptidase activity"
+      unit: "mole per liter per hour"
       dinaComponent: "COLLECTING_EVENT"
     - key: "ammonium"
       name: "ammonium"
       multilingualDescription.descriptions:
         - lang: en
           desc: "concentration of ammonium"
+      unit: "micromole per liter"
       dinaComponent: "COLLECTING_EVENT"
     - key: "bacteria_carb_prod"
       name: "bacterial carbon production"
       multilingualDescription.descriptions:
         - lang: en
           desc: "measurement of bacterial carbon production"
+      unit: "nanogram per hour"
       dinaComponent: "COLLECTING_EVENT"
     - key: "biomass"
       name: "biomass"
@@ -79,6 +84,7 @@ extension:
       multilingualDescription.descriptions:
         - lang: en
           desc: "concentration of chloride"
+      unit: "milligram per liter"
       dinaComponent: "COLLECTING_EVENT"
     - key: "chlorophyll"
       name: "chlorophyll"
@@ -91,30 +97,35 @@ extension:
       multilingualDescription.descriptions:
         - lang: en
           desc: "concentration of diether lipids; can include multiple types of diether lipids"
+      unit: "nanogram per liter"
       dinaComponent: "COLLECTING_EVENT"
     - key: "diss_carb_dioxide"
       name: "dissolved carbon dioxide"
       multilingualDescription.descriptions:
         - lang: en
           desc: "concentration of dissolved carbon dioxide"
+      unit: "micromole per liter"
       dinaComponent: "COLLECTING_EVENT"
     - key: "diss_hydrogen"
       name: "dissolved hydrogen"
       multilingualDescription.descriptions:
         - lang: en
           desc: "concentration of dissolved hydrogen"
+      unit: "micromole per liter"
       dinaComponent: "COLLECTING_EVENT"
     - key: "diss_inorg_carb"
       name: "dissolved inorganic carbon"
       multilingualDescription.descriptions:
         - lang: en
           desc: "dissolved inorganic carbon concentration"
+      unit: "microgram per liter"
       dinaComponent: "COLLECTING_EVENT"
     - key: "diss_org_carb"
       name: "dissolved organic carbon"
       multilingualDescription.descriptions:
         - lang: en
           desc: "concentration of dissolved organic carbon"
+      unit: "micromole per liter"
       dinaComponent: "COLLECTING_EVENT"
     - key: "diss_org_nitro"
       name: "dissolved organic nitrogen"
@@ -128,12 +139,14 @@ extension:
       multilingualDescription.descriptions:
         - lang: en
           desc: "concentration of dissolved oxygen"
+      unit: "micromole per liter"
       dinaComponent: "COLLECTING_EVENT"
     - key: "glucosidase_act"
       name: "glucosidase activity"
       multilingualDescription.descriptions:
         - lang: en
           desc: "measurement of glucosidase activity"
+      unit: "mol per liter per hour"
       dinaComponent: "COLLECTING_EVENT"
     - key: "magnesium"
       name: "magnesium"
@@ -146,60 +159,70 @@ extension:
       multilingualDescription.descriptions:
         - lang: en
           desc: "measurement of mean friction velocity"
+      unit: "meter per second"
       dinaComponent: "COLLECTING_EVENT"
     - key: "mean_peak_frict_vel"
       name: "mean peak friction velocity"
       multilingualDescription.descriptions:
         - lang: en
           desc: "measurement of mean peak friction velocity"
+      unit: "meter per second"
       dinaComponent: "COLLECTING_EVENT"
     - key: "methane"
       name: "methane"
       multilingualDescription.descriptions:
         - lang: en
           desc: "methane (gas) amount or concentration at the time of sampling"
+      unit: "micromole per liter"
       dinaComponent: "COLLECTING_EVENT"
     - key: "n_alkanes"
       name: "n-alkanes"
       multilingualDescription.descriptions:
         - lang: en
           desc: "concentration of n-alkanes; can include multiple n-alkanes"
+      unit: "micromole per liter"
       dinaComponent: "COLLECTING_EVENT"
     - key: "nitrate"
       name: "nitrate"
       multilingualDescription.descriptions:
         - lang: en
           desc: "concentration of nitrate"
+      unit: "micromole per liter"
       dinaComponent: "COLLECTING_EVENT"
     - key: "nitrite"
       name: "nitrite"
       multilingualDescription.descriptions:
         - lang: en
           desc: "concentration of nitrite"
+      unit: "micromole per liter"
       dinaComponent: "COLLECTING_EVENT"
     - key: "nitro"
       name: "nitrogen"
       multilingualDescription.descriptions:
         - lang: en
           desc: "concentration of nitrogen (total)"
+      unit: "micromole per liter"
       dinaComponent: "COLLECTING_EVENT"
     - key: "org_carb"
       name: "organic carbon"
       multilingualDescription.descriptions:
         - lang: en
           desc: "concentration of organic carbon"
+      unit: "micromole per liter"
       dinaComponent: "COLLECTING_EVENT"
     - key: "org_matter"
       name: "organic matter"
       multilingualDescription.descriptions:
         - lang: en
-          desc: "concentration of organic matter "
+          desc: "concentration of organic matter"
+      unit: "microgram per liter"
       dinaComponent: "COLLECTING_EVENT"
     - key: "org_nitro"
       name: "organic nitrogen"
       multilingualDescription.descriptions:
         - lang: en
           desc: "concentration of organic nitrogen"
+      unit: "microgram per liter"
       dinaComponent: "COLLECTING_EVENT"
     - key: "organism_count"
       name: "organism count"
@@ -219,6 +242,7 @@ extension:
       multilingualDescription.descriptions:
         - lang: en
           desc: "concentration of particulate organic carbon"
+      unit: "microgram per liter"
       dinaComponent: "COLLECTING_EVENT"
     - key: "perturbation"
       name: "perturbation"
@@ -232,6 +256,7 @@ extension:
       multilingualDescription.descriptions:
         - lang: en
           desc: "concentration of petroleum hydrocarbon"
+      unit: "micromole per liter"
       dinaComponent: "COLLECTING_EVENT"
     - key: "ph"
       name: "pH"
@@ -244,12 +269,14 @@ extension:
       multilingualDescription.descriptions:
         - lang: en
           desc: "concentration of phaeopigments; can include multiple phaeopigments"
+      unit: "milligram per cubic meter"
       dinaComponent: "COLLECTING_EVENT"
     - key: "phosphate"
       name: "phosphate"
       multilingualDescription.descriptions:
         - lang: en
           desc: "concentration of phosphate"
+      unit: "micromole per liter"
       dinaComponent: "COLLECTING_EVENT"
     - key: "phosplipid_fatt_acid"
       name: "phospholipid fatty acid"
@@ -268,6 +295,7 @@ extension:
       multilingualDescription.descriptions:
         - lang: en
           desc: "pressure to which the sample is subject, in atmospheres"
+      unit: "atmosphere"
       dinaComponent: "COLLECTING_EVENT"
     - key: "redox_potential"
       name: "redox potential"
@@ -275,6 +303,7 @@ extension:
         - lang: en
           desc: "redox potential, measured relative to a hydrogen cell, indicating oxidation\
         \ or reduction potential"
+      unit: "millivolt"
       dinaComponent: "COLLECTING_EVENT"
     - key: "salinity"
       name: "salinity"
@@ -299,6 +328,7 @@ extension:
       multilingualDescription.descriptions:
         - lang: en
           desc: "temperature at which sample was stored, e.g. -80 degree Celsius"
+      unit: "degree Celsius"
       dinaComponent: "COLLECTING_EVENT"
     - key: "samp_vol_we_dna_ext"
       name: "sample volume or weight for DNA extraction"
@@ -311,6 +341,7 @@ extension:
       multilingualDescription.descriptions:
         - lang: en
           desc: "concentration of silicate"
+      unit: "micromole per liter"
       dinaComponent: "COLLECTING_EVENT"
     - key: "sodium"
       name: "sodium"
@@ -335,12 +366,14 @@ extension:
       multilingualDescription.descriptions:
         - lang: en
           desc: "temperature of the sample at time of sampling"
+      unit: "degree Celsius"
       dinaComponent: "COLLECTING_EVENT"
     - key: "tot_carb"
       name: "total carbon"
       multilingualDescription.descriptions:
         - lang: en
           desc: "total carbon content"
+      unit: "microgram per liter"
       dinaComponent: "COLLECTING_EVENT"
     - key: "tot_nitro"
       name: "total nitrogen"

--- a/src/main/resources/extension/mixsPlantAssociatedv4.yml
+++ b/src/main/resources/extension/mixsPlantAssociatedv4.yml
@@ -11,6 +11,7 @@ extension:
           desc: "information about treatment involving an exposure to varying temperatures;\
         \ should include the temperature, treatment duration, interval and total experimental\
         \ duration; can include different temperature regimens"
+      unit: "degree Celsius"
       dinaComponent: "COLLECTING_EVENT"
     - key: "antibiotic_regm"
       name: "antibiotic regimen"
@@ -19,6 +20,7 @@ extension:
           desc: "information about treatment involving antibiotic administration; should include\
         \ the name of antibiotic, amount administered, treatment duration, interval and total\
         \ experimental duration; can include multiple antibiotic regimens"
+      unit: "milligram"
       dinaComponent: "COLLECTING_EVENT"
     - key: "chem_administration"
       name: "chemical administration"
@@ -36,6 +38,7 @@ extension:
           desc: "treatment involving use of mutagens; should include the name of mutagen, amount\
         \ administered, treatment duration, interval and total experimental duration; can include\
         \ multiple mutagen regimens"
+      unit: "milligram per liter"
       dinaComponent: "COLLECTING_EVENT"
     - key: "climate_environment"
       name: "climate environment"
@@ -67,6 +70,7 @@ extension:
           desc: "use of conditions with differing gaseous environments; should include the\
         \ name of gaseous compound, amount administered, treatment duration, interval and\
         \ total experimental duration; can include multiple gaseous environment regimens"
+      unit: "micromole per liter"
       dinaComponent: "COLLECTING_EVENT"
     - key: "gravity"
       name: "gravity"
@@ -197,6 +201,7 @@ extension:
         \ humidity; information about treatment involving use of growth hormones; should\
         \ include amount of humidity administered, treatment duration, interval and total\
         \ experimental duration; can include multiple regimens"
+      unit: "gram per cubic meter"
       dinaComponent: "COLLECTING_EVENT"
     - key: "mechanical_damage"
       name: "mechanical damage"
@@ -279,6 +284,7 @@ extension:
         \ a particular radiation regimen; should include the radiation type, amount or intensity\
         \ administered, treatment duration, interval and total experimental duration; can include\
         \ multiple radiation regimens"
+      unit: "becquerel"
       dinaComponent: "COLLECTING_EVENT"
     - key: "rainfall_regm"
       name: "rainfall regimen"
@@ -286,6 +292,7 @@ extension:
         - lang: en
           desc: "information about treatment involving an exposure to a given amount of rainfall;\
         \ can include multiple regimens"
+      unit: "millimeter"
       dinaComponent: "COLLECTING_EVENT"
     - key: "salt_regm"
       name: "salt regimen"
@@ -318,6 +325,7 @@ extension:
       multilingualDescription.descriptions:
         - lang: en
           desc: "temperature at which sample was stored, e.g. -80 degree Celsius"
+      unit: "degree Celsius"
       dinaComponent: "COLLECTING_EVENT"
     - key: "samp_vol_we_dna_ext"
       name: "sample volume or weight for DNA extraction"
@@ -344,6 +352,7 @@ extension:
       multilingualDescription.descriptions:
         - lang: en
           desc: "temperature of the sample at time of sampling"
+      unit: "degree Celsius"
       dinaComponent: "COLLECTING_EVENT"
     - key: "tiss_cult_growth_med"
       name: "tissue culture growth media"
@@ -357,6 +366,7 @@ extension:
         - lang: en
           desc: "information about treatment involving an exposure to water with varying degree\
         \ of temperature; can include multiple regimens"
+      unit: "degree Celsius"
       dinaComponent: "COLLECTING_EVENT"
     - key: "watering_regm"
       name: "watering regimen"

--- a/src/main/resources/extension/mixsSedimentv4.yml
+++ b/src/main/resources/extension/mixsSedimentv4.yml
@@ -10,30 +10,35 @@ extension:
         - lang: en
           desc: "alkalinity, the ability of a solution to neutralize acids to the equivalence\
         \ point of carbonate or bicarbonate"
+      unit: "milliequivalent per liter"
       dinaComponent: "COLLECTING_EVENT"
     - key: "alkyl_diethers"
       name: "alkyl diethers"
       multilingualDescription.descriptions:
         - lang: en
           desc: "concentration of alkyl diethers "
+      unit: "mole per liter"
       dinaComponent: "COLLECTING_EVENT"
     - key: "aminopept_act"
       name: "aminopeptidase activity"
       multilingualDescription.descriptions:
         - lang: en
           desc: "measurement of aminopeptidase activity"
+      unit: "mole per liter per hour"
       dinaComponent: "COLLECTING_EVENT"
     - key: "ammonium"
       name: "ammonium"
       multilingualDescription.descriptions:
         - lang: en
           desc: "concentration of ammonium"
+      unit: "micromole per liter"
       dinaComponent: "COLLECTING_EVENT"
     - key: "bacteria_carb_prod"
       name: "bacterial carbon production"
       multilingualDescription.descriptions:
         - lang: en
           desc: "measurement of bacterial carbon production"
+      unit: "nanogram per hour"
       dinaComponent: "COLLECTING_EVENT"
     - key: "biomass"
       name: "biomass"
@@ -53,6 +58,7 @@ extension:
       multilingualDescription.descriptions:
         - lang: en
           desc: "concentration of bromide"
+      unit: "parts per million"
       dinaComponent: "COLLECTING_EVENT"
     - key: "calcium"
       name: "calcium"
@@ -79,6 +85,7 @@ extension:
       multilingualDescription.descriptions:
         - lang: en
           desc: "concentration of chloride"
+      unit: "milligram per liter"
       dinaComponent: "COLLECTING_EVENT"
     - key: "chlorophyll"
       name: "chlorophyll"
@@ -91,36 +98,42 @@ extension:
       multilingualDescription.descriptions:
         - lang: en
           desc: "density of sample"
+      unit: "gram per cubic meter"
       dinaComponent: "COLLECTING_EVENT"
     - key: "diether_lipids"
       name: "diether lipids"
       multilingualDescription.descriptions:
         - lang: en
           desc: "concentration of diether lipids; can include multiple types of diether lipids"
+      unit: "nanogram per liter"
       dinaComponent: "COLLECTING_EVENT"
     - key: "diss_carb_dioxide"
       name: "dissolved carbon dioxide"
       multilingualDescription.descriptions:
         - lang: en
           desc: "concentration of dissolved carbon dioxide"
+      unit: "micromole per liter"
       dinaComponent: "COLLECTING_EVENT"
     - key: "diss_hydrogen"
       name: "dissolved hydrogen"
       multilingualDescription.descriptions:
         - lang: en
           desc: "concentration of dissolved hydrogen"
+      unit: "micromole per liter"
       dinaComponent: "COLLECTING_EVENT"
     - key: "diss_inorg_carb"
       name: "dissolved inorganic carbon"
       multilingualDescription.descriptions:
         - lang: en
           desc: "dissolved inorganic carbon concentration"
+      unit: "microgram per liter"
       dinaComponent: "COLLECTING_EVENT"
     - key: "diss_org_carb"
       name: "dissolved organic carbon"
       multilingualDescription.descriptions:
         - lang: en
           desc: "concentration of dissolved organic carbon"
+      unit: "micromole per liter"
       dinaComponent: "COLLECTING_EVENT"
     - key: "diss_org_nitro"
       name: "dissolved organic nitrogen"
@@ -134,12 +147,14 @@ extension:
       multilingualDescription.descriptions:
         - lang: en
           desc: "concentration of dissolved oxygen"
+      unit: "micromole per kilogram"
       dinaComponent: "COLLECTING_EVENT"
     - key: "glucosidase_act"
       name: "glucosidase activity"
       multilingualDescription.descriptions:
         - lang: en
           desc: "measurement of glucosidase activity"
+      unit: "mol per liter per hour"
       dinaComponent: "COLLECTING_EVENT"
     - key: "magnesium"
       name: "magnesium"
@@ -152,18 +167,21 @@ extension:
       multilingualDescription.descriptions:
         - lang: en
           desc: "measurement of mean friction velocity"
+      unit: "meter per second"
       dinaComponent: "COLLECTING_EVENT"
     - key: "mean_peak_frict_vel"
       name: "mean peak friction velocity"
       multilingualDescription.descriptions:
         - lang: en
           desc: "measurement of mean peak friction velocity"
+      unit: "meter per second"
       dinaComponent: "COLLECTING_EVENT"
     - key: "methane"
       name: "methane"
       multilingualDescription.descriptions:
         - lang: en
           desc: "methane (gas) amount or concentration at the time of sampling"
+      unit: "micromole per liter"
       dinaComponent: "COLLECTING_EVENT"
     - key: "misc_param"
       name: "miscellaneous parameter"
@@ -176,42 +194,49 @@ extension:
       multilingualDescription.descriptions:
         - lang: en
           desc: "concentration of n-alkanes; can include multiple n-alkanes"
+      unit: "micromole per liter"
       dinaComponent: "COLLECTING_EVENT"
     - key: "nitrate"
       name: "nitrate"
       multilingualDescription.descriptions:
         - lang: en
           desc: "concentration of nitrate"
+      unit: "micromole per liter"
       dinaComponent: "COLLECTING_EVENT"
     - key: "nitrite"
       name: "nitrite"
       multilingualDescription.descriptions:
         - lang: en
           desc: "concentration of nitrite"
+      unit: "micromole per liter"
       dinaComponent: "COLLECTING_EVENT"
     - key: "nitro"
       name: "nitrogen"
       multilingualDescription.descriptions:
         - lang: en
           desc: "concentration of nitrogen (total)"
+      unit: "micromole per liter"
       dinaComponent: "COLLECTING_EVENT"
     - key: "org_carb"
       name: "organic carbon"
       multilingualDescription.descriptions:
         - lang: en
           desc: "concentration of organic carbon"
+      unit: "micromole per liter"
       dinaComponent: "COLLECTING_EVENT"
     - key: "org_matter"
       name: "organic matter"
       multilingualDescription.descriptions:
         - lang: en
           desc: "concentration of organic matter"
+      unit: "microgram per liter"
       dinaComponent: "COLLECTING_EVENT"
     - key: "org_nitro"
       name: "organic nitrogen"
       multilingualDescription.descriptions:
         - lang: en
           desc: "concentration of organic nitrogen"
+      unit: "microgram per liter"
       dinaComponent: "COLLECTING_EVENT"
     - key: "organism_count"
       name: "organism count"
@@ -231,6 +256,7 @@ extension:
       multilingualDescription.descriptions:
         - lang: en
           desc: "concentration of particulate organic carbon"
+      unit: "microgram per liter"
       dinaComponent: "COLLECTING_EVENT"
     - key: "particle_class"
       name: "particle classification"
@@ -239,6 +265,7 @@ extension:
           desc: "particles are classified, based on their size, into six general categories:clay,\
         \ silt, sand, gravel, cobbles, and boulders; should include amount of particle preceded by\
         \ the name of the particle type; can include multiple values"
+      unit: "micrometer"
       dinaComponent: "COLLECTING_EVENT"
     - key: "perturbation"
       name: "perturbation"
@@ -252,6 +279,7 @@ extension:
       multilingualDescription.descriptions:
         - lang: en
           desc: "concentration of petroleum hydrocarbon"
+      unit: "micromole per liter"
       dinaComponent: "COLLECTING_EVENT"
     - key: "ph"
       name: "pH"
@@ -264,12 +292,14 @@ extension:
       multilingualDescription.descriptions:
         - lang: en
           desc: "concentration of phaeopigments; can include multiple phaeopigments"
+      unit: "milligram per cubic meter"
       dinaComponent: "COLLECTING_EVENT"
     - key: "phosphate"
       name: "phosphate"
       multilingualDescription.descriptions:
         - lang: en
           desc: "concentration of phosphate"
+      unit: "micromole per liter"
       dinaComponent: "COLLECTING_EVENT"
     - key: "phosplipid_fatt_acid"
       name: "phospholipid fatty acid"
@@ -283,18 +313,21 @@ extension:
         - lang: en
           desc: "porosity of deposited sediment is volume of voids divided by the total volume\
         \ of sample"
+      unit: "percentage"
       dinaComponent: "COLLECTING_EVENT"
     - key: "potassium"
       name: "potassium"
       multilingualDescription.descriptions:
         - lang: en
           desc: "concentration of potassium "
+      unit: "parts per million"
       dinaComponent: "COLLECTING_EVENT"
     - key: "pressure"
       name: "pressure"
       multilingualDescription.descriptions:
         - lang: en
           desc: "pressure to which the sample is subject, in atmospheres"
+      unit: "atmosphere"
       dinaComponent: "COLLECTING_EVENT"
     - key: "redox_potential"
       name: "redox potential"
@@ -302,6 +335,7 @@ extension:
         - lang: en
           desc: "redox potential, measured relative to a hydrogen cell, indicating oxidation or\
         \ reduction potential"
+      unit: "millivolt"
       dinaComponent: "COLLECTING_EVENT"
     - key: "salinity"
       name: "salinity"
@@ -326,6 +360,7 @@ extension:
       multilingualDescription.descriptions:
         - lang: en
           desc: "temperature at which sample was stored, e.g. -80 degree Celsius"
+      unit: "degree Celsius"
       dinaComponent: "COLLECTING_EVENT"
     - key: "samp_vol_we_dna_ext"
       name: "sample volume or weight for DNA extraction"
@@ -344,6 +379,7 @@ extension:
       multilingualDescription.descriptions:
         - lang: en
           desc: "concentration of silicate"
+      unit: "micromole per liter"
       dinaComponent: "COLLECTING_EVENT"
     - key: "sodium"
       name: "sodium"
@@ -368,6 +404,7 @@ extension:
       multilingualDescription.descriptions:
         - lang: en
           desc: "temperature of the sample at time of sampling"
+      unit: "degree Celsius"
       dinaComponent: "COLLECTING_EVENT"
     - key: "tidal_stage"
       name: "tidal stage"
@@ -380,6 +417,7 @@ extension:
       multilingualDescription.descriptions:
         - lang: en
           desc: "total carbon content"
+      unit: "microgram per liter"
       dinaComponent: "COLLECTING_EVENT"
     - key: "tot_nitro"
       name: "total nitrogen"

--- a/src/main/resources/extension/mixsSedimentv5.yml
+++ b/src/main/resources/extension/mixsSedimentv5.yml
@@ -60,6 +60,7 @@ extension:
       multilingualDescription.descriptions:
         - lang: en
           desc: "Please refer to the definitions of depth in the environmental packages"
+      unit: "meter"
       dinaComponent: "COLLECTING_EVENT"
     - key: "alt_elev"
       name: "geographic location (altitude/elevation)"
@@ -755,6 +756,7 @@ extension:
         \ point, most commonly the mean sea level. Elevation is mainly used when referring\
         \ to points on the earth's surface, while altitude is used for points above\
         \ the surface, such as an aircraft in flight or a spacecraft in orbit"
+      unit: "meter"
       dinaComponent: "COLLECTING_EVENT"
     - key: "alkalinity"
       name: "alkalinity"
@@ -768,12 +770,14 @@ extension:
       multilingualDescription.descriptions:
         - lang: en
           desc: "Concentration of alkyl diethers"
+      unit: "mole per liter"
       dinaComponent: "COLLECTING_EVENT"
     - key: "aminopept_act"
       name: "aminopeptidase activity"
       multilingualDescription.descriptions:
         - lang: en
           desc: "Measurement of aminopeptidase activity"
+      unit: "mole per liter per hour"
       dinaComponent: "COLLECTING_EVENT"
     - key: "ammonium"
       name: "ammonium"
@@ -786,6 +790,7 @@ extension:
       multilingualDescription.descriptions:
         - lang: en
           desc: "Measurement of bacterial carbon production"
+      unit: "nanogram per hour"
       dinaComponent: "COLLECTING_EVENT"
     - key: "biomass"
       name: "biomass"
@@ -805,6 +810,7 @@ extension:
       multilingualDescription.descriptions:
         - lang: en
           desc: "Concentration of bromide"
+      unit: "parts per million"
       dinaComponent: "COLLECTING_EVENT"
     - key: "calcium"
       name: "calcium"
@@ -852,6 +858,7 @@ extension:
         - lang: en
           desc: "Concentration of diether lipids; can include multiple types of diether\
         \ lipids"
+      unit: "nanogram per liter"
       dinaComponent: "COLLECTING_EVENT"
     - key: "diss_carb_dioxide"
       name: "dissolved carbon dioxide"
@@ -865,6 +872,7 @@ extension:
       multilingualDescription.descriptions:
         - lang: en
           desc: "Concentration of dissolved hydrogen"
+      unit: "micromole per liter"
       dinaComponent: "COLLECTING_EVENT"
     - key: "diss_inorg_carb"
       name: "dissolved inorganic carbon"
@@ -898,6 +906,7 @@ extension:
       multilingualDescription.descriptions:
         - lang: en
           desc: "Measurement of glucosidase activity"
+      unit: "mol per liter per hour"
       dinaComponent: "COLLECTING_EVENT"
     - key: "magnesium"
       name: "magnesium"
@@ -910,12 +919,14 @@ extension:
       multilingualDescription.descriptions:
         - lang: en
           desc: "Measurement of mean friction velocity"
+      unit: "meter per second"
       dinaComponent: "COLLECTING_EVENT"
     - key: "mean_peak_frict_vel"
       name: "mean peak friction velocity"
       multilingualDescription.descriptions:
         - lang: en
           desc: "Measurement of mean peak friction velocity"
+      unit: "meter per second"
       dinaComponent: "COLLECTING_EVENT"
     - key: "methane"
       name: "methane"
@@ -935,6 +946,7 @@ extension:
       multilingualDescription.descriptions:
         - lang: en
           desc: "Concentration of n-alkanes; can include multiple n-alkanes"
+      unit: "micromole per liter"
       dinaComponent: "COLLECTING_EVENT"
     - key: "nitrate"
       name: "nitrate"
@@ -953,24 +965,28 @@ extension:
       multilingualDescription.descriptions:
         - lang: en
           desc: "Concentration of nitrogen (total)"
+      unit: "micromole per liter"
       dinaComponent: "COLLECTING_EVENT"
     - key: "org_carb"
       name: "organic carbon"
       multilingualDescription.descriptions:
         - lang: en
           desc: "Concentration of organic carbon"
+      unit: "micromole per liter"
       dinaComponent: "COLLECTING_EVENT"
     - key: "org_matter"
       name: "organic matter"
       multilingualDescription.descriptions:
         - lang: en
           desc: "Concentration of organic matter"
+      unit: "microgram per liter"
       dinaComponent: "COLLECTING_EVENT"
     - key: "org_nitro"
       name: "organic nitrogen"
       multilingualDescription.descriptions:
         - lang: en
           desc: "Concentration of organic nitrogen"
+      unit: "microgram per liter"
       dinaComponent: "COLLECTING_EVENT"
     - key: "organism_count"
       name: "organism count"
@@ -1007,6 +1023,7 @@ extension:
       multilingualDescription.descriptions:
         - lang: en
           desc: "Concentration of particulate organic carbon"
+      unit: "microgram per liter"
       dinaComponent: "COLLECTING_EVENT"
     - key: "perturbation"
       name: "perturbation"
@@ -1022,18 +1039,21 @@ extension:
       multilingualDescription.descriptions:
         - lang: en
           desc: "Concentration of petroleum hydrocarbon"
+      unit: "micromole gram per liter"
       dinaComponent: "COLLECTING_EVENT"
     - key: "phaeopigments"
       name: "phaeopigments"
       multilingualDescription.descriptions:
         - lang: en
           desc: "Concentration of phaeopigments; can include multiple phaeopigments"
+      unit: "milligram per cubic meter"
       dinaComponent: "COLLECTING_EVENT"
     - key: "phosphate"
       name: "phosphate"
       multilingualDescription.descriptions:
         - lang: en
           desc: "Concentration of phosphate"
+      unit: "micromole per liter"
       dinaComponent: "COLLECTING_EVENT"
     - key: "phosplipid_fatt_acid"
       name: "phospholipid fatty acid"
@@ -1047,6 +1067,7 @@ extension:
         - lang: en
           desc: "Porosity of deposited sediment is volume of voids divided by the\
         \ total volume of sample"
+      unit: "percentage"
       dinaComponent: "COLLECTING_EVENT"
     - key: "potassium"
       name: "potassium"
@@ -1059,6 +1080,7 @@ extension:
       multilingualDescription.descriptions:
         - lang: en
           desc: "Pressure to which the sample is subject to, in atmospheres"
+      unit: "atmosphere"
       dinaComponent: "COLLECTING_EVENT"
     - key: "redox_potential"
       name: "redox potential"
@@ -1066,6 +1088,7 @@ extension:
         - lang: en
           desc: "Redox potential, measured relative to a hydrogen cell, indicating\
         \ oxidation or reduction potential"
+      unit: "millivolt"
       dinaComponent: "COLLECTING_EVENT"
     - key: "salinity"
       name: "salinity"
@@ -1095,6 +1118,7 @@ extension:
       multilingualDescription.descriptions:
         - lang: en
           desc: "Temperature at which sample was stored, e.g. -80 degree Celsius"
+      unit: "degree Celsius"
       dinaComponent: "COLLECTING_EVENT"
     - key: "samp_vol_we_dna_ext"
       name: "sample volume or weight for DNA extraction"
@@ -1114,6 +1138,7 @@ extension:
       multilingualDescription.descriptions:
         - lang: en
           desc: "Concentration of silicate"
+      unit: "micromole per liter"
       dinaComponent: "COLLECTING_EVENT"
     - key: "sodium"
       name: "sodium"
@@ -1138,6 +1163,7 @@ extension:
       multilingualDescription.descriptions:
         - lang: en
           desc: "Temperature of the sample at the time of sampling"
+      unit: "degree Celsius"
       dinaComponent: "COLLECTING_EVENT"
     - key: "tidal_stage"
       name: "tidal stage"
@@ -1150,12 +1176,14 @@ extension:
       multilingualDescription.descriptions:
         - lang: en
           desc: "Total carbon content"
+      unit: "microgram per liter"
       dinaComponent: "COLLECTING_EVENT"
     - key: "tot_depth_water_col"
       name: "total depth of water column"
       multilingualDescription.descriptions:
         - lang: en
           desc: "Measurement of total depth of water column"
+      unit: "meter"
       dinaComponent: "COLLECTING_EVENT"
     - key: "tot_nitro_content"
       name: "total nitrogen content"

--- a/src/main/resources/extension/mixsSoilv4.yml
+++ b/src/main/resources/extension/mixsSoilv4.yml
@@ -453,6 +453,7 @@ extension:
         - lang: en
           desc: "the altitude of the sample is the vertical distance between Earth's surface\
         \ above sea level and the sampled position in the air"
+      unit: "meter"
       dinaComponent: "COLLECTING_EVENT"
     - key: "depth"
       name: "depth"
@@ -468,6 +469,7 @@ extension:
         - lang: en
           desc: "the elevation of the sampling site as measured by the vertical distance from\
         \ mean sea level"
+      unit: "meter"
       dinaComponent: "COLLECTING_EVENT"
     - key: "cur_land_use"
       name: "current land use"
@@ -595,12 +597,14 @@ extension:
       multilingualDescription.descriptions:
         - lang: en
           desc: "mean annual and seasonal temperature"
+      unit: "degree Celsius"
       dinaComponent: "COLLECTING_EVENT"
     - key: "annual_season_precpt"
       name: "mean annual and seasonal precipitation"
       multilingualDescription.descriptions:
         - lang: en
           desc: "mean annual and seasonal precipitation"
+      unit: "millimeter"
       dinaComponent: "COLLECTING_EVENT"
     - key: "link_class_info"
       name: "link to classification information"
@@ -646,6 +650,7 @@ extension:
           desc: "commonly called 'slope'. The angle between ground surface and a horizontal\
         \ line (in percent). This is the direction that overland water would flow. This\
         \ measure is usually taken with a hand level meter or clinometer"
+      unit: "percentage"
       dinaComponent: "COLLECTING_EVENT"
     - key: "slope_aspect"
       name: "slope aspect"
@@ -654,6 +659,7 @@ extension:
           desc: "the direction a slope faces. While looking down a slope use a compass to\
         \ record the direction you are facing (direction or degrees); e.g., NW or 315\
         \ degrees. This measure provides an indication of sun and wind exposure that will influence soil temperature and evapotranspiration."
+      unit: "degree"
       dinaComponent: "COLLECTING_EVENT"
     - key: "profile_position"
       name: "profile position"
@@ -745,6 +751,7 @@ extension:
       multilingualDescription.descriptions:
         - lang: en
           desc: "measured salinity"
+      unit: "millisiemens per meter"
       dinaComponent: "COLLECTING_EVENT"
     - key: "salinity_meth"
       name: "extreme_unusual_properties/salinity method"
@@ -758,6 +765,7 @@ extension:
         - lang: en
           desc: "heavy metals present and concentrationsany drug used by subject and\
         \ the frequency of usage; can include multiple heavy metals and concentrations"
+      unit: "microgram per gram"
       dinaComponent: "COLLECTING_EVENT"
     - key: "heavy_metals_meth"
       name: "extreme_unusual_properties/heavy metals method"
@@ -770,6 +778,7 @@ extension:
       multilingualDescription.descriptions:
         - lang: en
           desc: "aluminum saturation (esp. for tropical soils)"
+      unit: "percentage"
       dinaComponent: "COLLECTING_EVENT"
     - key: "al_sat_meth"
       name: "extreme_unusual_properties/Al saturation method"

--- a/src/main/resources/extension/mixsSoilv4.yml
+++ b/src/main/resources/extension/mixsSoilv4.yml
@@ -20,7 +20,7 @@ extension:
         \ Webin/Sequin systems to Genbank, ENA and DDBJ. Although this field is\
         \ mandatory, it is meant as a self-test field, therefore it is not necessary\
         \ to include this field in contextual data submitted to databases"
-      dinaComponentnaComponent: "COLLECTING_EVENT"
+      dinaComponent: "COLLECTING_EVENT"
     - key: "investigation_type"
       name: "investigation type"
       multilingualDescription.descriptions:
@@ -446,7 +446,6 @@ extension:
           desc: "Standard operating procedures used in assembly and/or annotation of genomes,\
         \ metagenomes or environmental sequences"
       dinaComponent: "COLLECTING_EVENT"
-    ###
     - key: "alt"
       name: "altitude"
       multilingualDescription.descriptions:

--- a/src/main/resources/extension/mixsSoilv5.yml
+++ b/src/main/resources/extension/mixsSoilv5.yml
@@ -746,6 +746,7 @@ extension:
           desc: "Depth is defined as the vertical distance below local surface, e.g.\
         \ For sediment or soil samples depth is measured from sediment or soil surface,\
         \ respectively. Depth can be reported as an interval for subsurface samples"
+      unit: "meter"
       dinaComponent: "COLLECTING_EVENT"
     - key: "elev"
       name: "elevation"
@@ -755,6 +756,7 @@ extension:
         \ point, most commonly the mean sea level. Elevation is mainly used when referring\
         \ to points on the earth's surface, while altitude is used for points above\
         \ the surface, such as an aircraft in flight or a spacecraft in orbit"
+      unit: "meter"
       dinaComponent: "COLLECTING_EVENT"
     - key: "cur_land_use"
       name: "current land use"
@@ -888,12 +890,14 @@ extension:
       multilingualDescription.descriptions:
         - lang: en
           desc: "Mean annual temperature"
+      unit: "degree Celsius"
       dinaComponent: "COLLECTING_EVENT"
     - key: "season_temp"
       name: "mean seasonal temperature"
       multilingualDescription.descriptions:
         - lang: en
           desc: "Mean seasonal temperature"
+      unit: "degree Celsius"
       dinaComponent: "COLLECTING_EVENT"
     - key: "annual_precpt"
       name: "mean annual precipitation"
@@ -902,6 +906,7 @@ extension:
           desc: "The average of all annual precipitation values known, or an estimated\
         \ equivalent value derived by such methods as regional indexes or Isohyetal\
         \ maps."
+      unit: "millimeter"
       dinaComponent: "COLLECTING_EVENT"
     - key: "season_precpt"
       name: "mean seasonal precipitation"
@@ -910,6 +915,7 @@ extension:
           desc: "The average of all seasonal precipitation values known, or an estimated\
         \ equivalent value derived by such methods as regional indexes or Isohyetal\
         \ maps."
+      unit: "millimeter"
       dinaComponent: "COLLECTING_EVENT"
     - key: "link_class_info"
       name: "link to classification information"
@@ -956,6 +962,7 @@ extension:
           desc: "Commonly called 'slope'. The angle between ground surface and a horizontal\
         \ line (in percent). This is the direction that overland water would flow. This\
         \ measure is usually taken with a hand level meter or clinometer"
+      unit: "percentage"
       dinaComponent: "COLLECTING_EVENT"
     - key: "slope_aspect"
       name: "slope aspect"
@@ -965,6 +972,7 @@ extension:
         \ to record the direction you are facing (direction or degrees); e.g., nw or\
         \ 315 degrees. This measure provides an indication of sun and wind exposure\
         \ that will influence soil temperature and evapotranspiration."
+      unit: "degree"
       dinaComponent: "COLLECTING_EVENT"
     - key: "profile_position"
       name: "profile position"
@@ -1057,6 +1065,7 @@ extension:
       multilingualDescription.descriptions:
         - lang: en
           desc: "Measured salinity"
+      unit: "millisiemens per meter"
       dinaComponent: "COLLECTING_EVENT"
     - key: "salinity_meth"
       name: "extreme_unusual_properties/salinity method"
@@ -1070,6 +1079,7 @@ extension:
         - lang: en
           desc: "Heavy metals present and concentrationsany drug used by subject and\
         \ the frequency of usage; can include multiple heavy metals and concentrations"
+      unit: "microgram per gram"
       dinaComponent: "COLLECTING_EVENT"
     - key: "heavy_metals_meth"
       name: "extreme_unusual_properties/heavy metals method"
@@ -1082,6 +1092,7 @@ extension:
       multilingualDescription.descriptions:
         - lang: en
           desc: "Aluminum saturation (esp. For tropical soils)"
+      unit: "percentage"
       dinaComponent: "COLLECTING_EVENT"
     - key: "al_sat_meth"
       name: "extreme_unusual_properties/Al saturation method"

--- a/src/main/resources/extension/mixsWaterv4.yml
+++ b/src/main/resources/extension/mixsWaterv4.yml
@@ -38,6 +38,7 @@ extension:
       multilingualDescription.descriptions:
         - lang: en
           desc: "measurement of atmospheric data; can include multiple data"
+      dinaComponent: "COLLECTING_EVENT"
     - key: "bac_prod"
       name: "bacterial production"
       multilingualDescription.descriptions:
@@ -162,6 +163,7 @@ extension:
         - lang: en
           desc: "concentration of dissolved inorganic nitrogen"
       unit: "microgram per liter"
+      dinaComponent: "COLLECTING_EVENT"
     - key: "diss_inorg_phosp"
       name: "dissolved inorganic phosphorus"
       multilingualDescription.descriptions:
@@ -202,6 +204,7 @@ extension:
       multilingualDescription.descriptions:
         - lang: en
           desc: "raw or converted fluorescence of water"
+      dinaComponent: "COLLECTING_EVENT"
     - key: "glucosidase_act"
       name: "glucosidase activity"
       multilingualDescription.descriptions:
@@ -317,6 +320,7 @@ extension:
         - lang: en
           desc: "type of perturbation, e.g. chemical administration, physical disturbance, etc.,\
         \ coupled with time that perturbation occurred; can include multiple perturbation types"
+      dinaComponent: "COLLECTING_EVENT"
     - key: "petroleum_hydrocarb"
       name: "petroleum hydrocarbon"
       multilingualDescription.descriptions:
@@ -396,6 +400,7 @@ extension:
       multilingualDescription.descriptions:
         - lang: en
           desc: "duration for which sample was stored"
+      dinaComponent: "COLLECTING_EVENT"
     - key: "samp_store_loc"
       name: "sample storage location"
       multilingualDescription.descriptions:

--- a/src/main/resources/extension/mixsWaterv4.yml
+++ b/src/main/resources/extension/mixsWaterv4.yml
@@ -10,24 +10,28 @@ extension:
         - lang: en
           desc: "alkalinity, the ability of a solution to neutralize acids to the equivalence point\
         \ of carbonate or bicarbonate"
+      unit: "milliequivalent per liter"
       dinaComponent: "COLLECTING_EVENT"
     - key: "alkyl_diethers"
       name: "alkyl diethers"
       multilingualDescription.descriptions:
         - lang: en
           desc: "concentration of alkyl diethers "
+      unit: "mole per liter"
       dinaComponent: "COLLECTING_EVENT"
     - key: "aminopept_act"
       name: "aminopeptidase activity"
       multilingualDescription.descriptions:
         - lang: en
           desc: "measurement of aminopeptidase activity"
+      unit: "mole per liter per hour"
       dinaComponent: "COLLECTING_EVENT"
     - key: "ammonium"
       name: "ammonium"
       multilingualDescription.descriptions:
         - lang: en
           desc: "concentration of ammonium"
+      unit: "micromole per liter"
       dinaComponent: "COLLECTING_EVENT"
     - key: "atmospheric_data"
       name: "atmospheric data"
@@ -39,18 +43,21 @@ extension:
       multilingualDescription.descriptions:
         - lang: en
           desc: "bacterial production in the water column measured by isotope uptake"
+      unit: "milligram per cubic meter per day"
       dinaComponent: "COLLECTING_EVENT"
     - key: "bac_resp"
       name: "bacterial respiration"
       multilingualDescription.descriptions:
         - lang: en
           desc: "measurement of bacterial resporation in the water column"
+      unit: "milligram per cubic meter per day"
       dinaComponent: "COLLECTING_EVENT"
     - key: "bacteria_carb_prod"
       name: "bacterial carbon production"
       multilingualDescription.descriptions:
         - lang: en
           desc: "measurement of bacterial carbon production"
+      unit: "nanogram per hour"
       dinaComponent: "COLLECTING_EVENT"
     - key: "biomass"
       name: "biomass"
@@ -70,6 +77,8 @@ extension:
       multilingualDescription.descriptions:
         - lang: en
           desc: "concentration of bromide"
+      unit: "parts per million"
+      dinaComponent: "COLLECTING_EVENT"
     - key: "calcium"
       name: "calcium"
       multilingualDescription.descriptions:
@@ -96,6 +105,7 @@ extension:
       multilingualDescription.descriptions:
         - lang: en
           desc: "concentration of chloride"
+      unit: "milligram per liter"
       dinaComponent: "COLLECTING_EVENT"
     - key: "chlorophyll"
       name: "chlorophyll"
@@ -108,11 +118,14 @@ extension:
       multilingualDescription.descriptions:
         - lang: en
           desc: "electrical conductivity of water"
+      unit: "milliSiemens per centimeter"
+      dinaComponent: "COLLECTING_EVENT"
     - key: "density"
       name: "density"
       multilingualDescription.descriptions:
         - lang: en
           desc: "density of sample"
+      unit: "gram per cubic meter"
       dinaComponent: "COLLECTING_EVENT"
     - key: "diether_lipids"
       name: "diether lipids"
@@ -120,41 +133,48 @@ extension:
         - lang: en
           desc: "concentration of diether lipids; can include multiple types of diether\
         \ lipids"
+      unit: "nanogram per liter"
       dinaComponent: "COLLECTING_EVENT"
     - key: "diss_carb_dioxide"
       name: "dissolved carbon dioxide"
       multilingualDescription.descriptions:
         - lang: en
           desc: "concentration of dissolved carbon dioxide"
+      unit: "micromole per liter"
       dinaComponent: "COLLECTING_EVENT"
     - key: "diss_hydrogen"
       name: "dissolved hydrogen"
       multilingualDescription.descriptions:
         - lang: en
           desc: "concentration of dissolved hydrogen"
+      unit: "micromole per liter"
       dinaComponent: "COLLECTING_EVENT"
     - key: "diss_inorg_carb"
       name: "dissolved inorganic carbon"
       multilingualDescription.descriptions:
         - lang: en
           desc: "dissolved inorganic carbon concentration"
+      unit: "microgram per liter"
       dinaComponent: "COLLECTING_EVENT"
     - key: "diss_inorg_nitro"
       name: "dissolved inorganic nitrogen"
       multilingualDescription.descriptions:
         - lang: en
           desc: "concentration of dissolved inorganic nitrogen"
+      unit: "microgram per liter"
     - key: "diss_inorg_phosp"
       name: "dissolved inorganic phosphorus"
       multilingualDescription.descriptions:
         - lang: en
           desc: "concentration of dissolved inorganic phosphorus"
+      unit: "microgram per liter"
       dinaComponent: "COLLECTING_EVENT"
     - key: "diss_org_carb"
       name: "dissolved organic carbon"
       multilingualDescription.descriptions:
         - lang: en
           desc: "concentration of dissolved organic carbon"
+      unit: "micromole per liter"
       dinaComponent: "COLLECTING_EVENT"
     - key: "diss_org_nitro"
       name: "dissolved organic nitrogen"
@@ -168,12 +188,14 @@ extension:
       multilingualDescription.descriptions:
         - lang: en
           desc: "concentration of dissolved oxygen"
+      unit: "micromole per liter"
       dinaComponent: "COLLECTING_EVENT"
     - key: "down_par"
       name: "downward PAR"
       multilingualDescription.descriptions:
         - lang: en
           desc: "visible waveband radiance and irradiance measurements in the water column"
+      unit: "microEinstein per meter per second"
       dinaComponent: "COLLECTING_EVENT"
     - key: "fluor"
       name: "fluorescence"
@@ -185,6 +207,7 @@ extension:
       multilingualDescription.descriptions:
         - lang: en
           desc: "measurement of glucosidase activity"
+      unit: "mol per liter per hour"
       dinaComponent: "COLLECTING_EVENT"
     - key: "light_intensity"
       name: "light intensity"
@@ -203,53 +226,63 @@ extension:
       multilingualDescription.descriptions:
         - lang: en
           desc: "measurement of mean friction velocity"
+      unit: "meter per second"
       dinaComponent: "COLLECTING_EVENT"
     - key: "mean_peak_frict_vel"
       name: "mean peak friction velocity"
       multilingualDescription.descriptions:
         - lang: en
           desc: "measurement of mean peak friction velocity"
+      unit: "meter per second"
       dinaComponent: "COLLECTING_EVENT"
     - key: "n_alkanes"
       name: "n-alkanes"
       multilingualDescription.descriptions:
         - lang: en
           desc: "concentration of n-alkanes; can include multiple n-alkanes"
+      unit: "micromole per liter"
       dinaComponent: "COLLECTING_EVENT"
     - key: "nitrate"
       name: "nitrate"
       multilingualDescription.descriptions:
         - lang: en
           desc: "concentration of nitrate"
+      unit: "micromole per liter"
       dinaComponent: "COLLECTING_EVENT"
     - key: "nitrite"
       name: "nitrite"
       multilingualDescription.descriptions:
         - lang: en
           desc: "concentration of nitrate"
+      unit: "micromole per liter"
       dinaComponent: "COLLECTING_EVENT"
     - key: "nitro"
       name: "nitrogen"
       multilingualDescription.descriptions:
         - lang: en
           desc: "concentration of nitrogen (total)"
+      unit: "micromole per liter"
       dinaComponent: "COLLECTING_EVENT"
     - key: "org_carb"
       name: "organic carbon"
       multilingualDescription.descriptions:
         - lang: en
           desc: "concentration of organic carbon"
+      unit: "micromole per liter"
       dinaComponent: "COLLECTING_EVENT"
     - key: "org_matter"
       name: "organic matter"
       multilingualDescription.descriptions:
         - lang: en
           desc: "concentration of organic matter"
+      unit: "microgram per liter"
+      dinaComponent: "COLLECTING_EVENT"
     - key: "org_nitro"
       name: "organic nitrogen"
       multilingualDescription.descriptions:
         - lang: en
           desc: "concentration of organic nitrogen"
+      unit: "microgram per liter"
       dinaComponent: "COLLECTING_EVENT"
     - key: "organism_count"
       name: "organism count"
@@ -269,12 +302,14 @@ extension:
       multilingualDescription.descriptions:
         - lang: en
           desc: "concentration of particulate organic carbon"
+      unit: "microgram per liter"
       dinaComponent: "COLLECTING_EVENT"
     - key: "part_org_nitro"
       name: "particulate organic nitrogen"
       multilingualDescription.descriptions:
         - lang: en
           desc: "concentration of particulate organic nitrogen"
+      unit: "microgram per liter"
       dinaComponent: "COLLECTING_EVENT"
     - key: "perturbation"
       name: "perturbation"
@@ -287,6 +322,7 @@ extension:
       multilingualDescription.descriptions:
         - lang: en
           desc: "concentration of petroleum hydrocarbon"
+      unit: "micromole per liter"
       dinaComponent: "COLLECTING_EVENT"
     - key: "ph"
       name: "pH"
@@ -299,12 +335,14 @@ extension:
       multilingualDescription.descriptions:
         - lang: en
           desc: "concentration of phaeopigments; can include multiple phaeopigments"
+      unit: "milligram per cubic meter"
       dinaComponent: "COLLECTING_EVENT"
     - key: "phosphate"
       name: "phosphate"
       multilingualDescription.descriptions:
         - lang: en
           desc: "concentration of phosphate"
+      unit: "micromole per liter"
       dinaComponent: "COLLECTING_EVENT"
     - key: "phosplipid_fatt_acid"
       name: "phospholipid fatty acid"
@@ -317,17 +355,21 @@ extension:
       multilingualDescription.descriptions:
         - lang: en
           desc: "measurement of photon flux"
+      unit: "micromole per square meter per second"
+      dinaComponent: "COLLECTING_EVENT"
     - key: "potassium"
       name: "potassium"
       multilingualDescription.descriptions:
         - lang: en
           desc: "concentration of potassium"
+      unit: "parts per million"
       dinaComponent: "COLLECTING_EVENT"
     - key: "pressure"
       name: "pressure"
       multilingualDescription.descriptions:
         - lang: en
           desc: "pressure to which the sample is subject, in atmospheres"
+      unit: "atmosphere"
       dinaComponent: "COLLECTING_EVENT"
     - key: "primary_prod"
       name: "primary production"
@@ -341,6 +383,7 @@ extension:
         - lang: en
           desc: "redox potential, measured relative to a hydrogen cell, indicating oxidation\
         \ or reduction potential"
+      unit: "millivolt"
       dinaComponent: "COLLECTING_EVENT"
     - key: "salinity"
       name: "salinity"
@@ -364,6 +407,7 @@ extension:
       multilingualDescription.descriptions:
         - lang: en
           desc: "temperature at which sample was stored, e.g. -80 degree Celsius"
+      unit: "degree Celsius"
       dinaComponent: "COLLECTING_EVENT"
     - key: "samp_vol_we_dna_ext"
       name: "sample volume or weight for DNA extraction"
@@ -376,18 +420,22 @@ extension:
       multilingualDescription.descriptions:
         - lang: en
           desc: "concentration of silicate"
+      unit: "micromole per liter"
       dinaComponent: "COLLECTING_EVENT"
     - key: "sodium"
       name: "sodium"
       multilingualDescription.descriptions:
         - lang: en
           desc: "sodium concentration"
+      unit: "parts per million"
       dinaComponent: "COLLECTING_EVENT"
     - key: "soluble_react_phosp"
       name: "soluble reactive phosphorus"
       multilingualDescription.descriptions:
         - lang: en
           desc: "concentration of soluble reactive phosphorus"
+      unit: "micromole per liter"
+      dinaComponent: "COLLECTING_EVENT"
     - key: "sulfate"
       name: "sulfate"
       multilingualDescription.descriptions:
@@ -405,12 +453,14 @@ extension:
       multilingualDescription.descriptions:
         - lang: en
           desc: "concentration of suspended particulate matter"
+      unit: "milligram per liter"
       dinaComponent: "COLLECTING_EVENT"
     - key: "temp"
       name: "temperature"
       multilingualDescription.descriptions:
         - lang: en
           desc: "temperature of the sample at time of sampling"
+      unit: "degree Celsius"
       dinaComponent: "COLLECTING_EVENT"
     - key: "tidal_stage"
       name: "tidal stage"
@@ -423,18 +473,22 @@ extension:
       multilingualDescription.descriptions:
         - lang: en
           desc: "measurement of total depth of water column"
+      unit: "meter"
+      dinaComponent: "COLLECTING_EVENT"
     - key: "tot_diss_nitro"
       name: "total dissolved nitrogen"
       multilingualDescription.descriptions:
         - lang: en
           desc: "total dissolved nitrogen concentration, reported as nitrogen, measured by:\
         \ total dissolved nitrogen = NH4 + NO3NO2 + dissolved organic nitrogen"
+      unit: "microgram per liter"
       dinaComponent: "COLLECTING_EVENT"
     - key: "tot_inorg_nitro"
       name: "total inorganic nitrogen"
       multilingualDescription.descriptions:
         - lang: en
           desc: "total inorganic nitrogen content"
+      unit: "microgram per liter"
       dinaComponent: "COLLECTING_EVENT"
     - key: "tot_nitro"
       name: "total nitrogen"
@@ -457,6 +511,7 @@ extension:
           desc: "total phosphorus concentration, calculated by: total phosphorus = total\
         \ dissolved phosphorus + particulate phosphorus. Can also be measured without filtering,\
         \ reported as phosphorus"
+      unit: "micromole per liter"
       dinaComponent: "COLLECTING_EVENT"
     - key: "water_current"
       name: "water current"


### PR DESCRIPTION
Added units to the v4 and v5 MIxS yml files when only a single, unambiguous preferred unit was provided.