### PR TITLE
Support #38644 - Add targetOrganismPrimaryTypeStatus field to material sample

### DIFF
--- a/src/main/java/ca/gc/aafc/collection/api/dto/MaterialSampleDto.java
+++ b/src/main/java/ca/gc/aafc/collection/api/dto/MaterialSampleDto.java
@@ -88,6 +88,10 @@ public class MaterialSampleDto implements DinaDto {
 
   @DiffIgnore
   @JsonInclude(JsonInclude.Include.NON_NULL)
+  private String targetOrganismPrimaryTypeStatus;
+
+  @DiffIgnore
+  @JsonInclude(JsonInclude.Include.NON_NULL)
   private Map<String, String> targetOrganismPrimaryClassification;
 
   @DiffIgnore

--- a/src/main/java/ca/gc/aafc/collection/api/entities/MaterialSample.java
+++ b/src/main/java/ca/gc/aafc/collection/api/entities/MaterialSample.java
@@ -138,6 +138,9 @@ public class MaterialSample extends AbstractMaterialSample {
   private String targetOrganismPrimaryScientificName;
 
   @Transient
+  private String targetOrganismPrimaryTypeStatus;
+  
+  @Transient
   private Map<String, String> targetOrganismPrimaryClassification;
 
   @Transient

--- a/src/main/java/ca/gc/aafc/collection/api/service/MaterialSampleService.java
+++ b/src/main/java/ca/gc/aafc/collection/api/service/MaterialSampleService.java
@@ -106,6 +106,7 @@ public class MaterialSampleService extends MessageProducingService<MaterialSampl
   public void augmentEntity(MaterialSample ms, Set<String> relationships) {
     if (relationships.contains(MaterialSample.ORGANISM_PROP_NAME)) {
       setTargetOrganismPrimaryScientificName(ms);
+      setTargetOrganismPrimaryTypeStatus(ms);
       setEffectiveScientificName(ms);
       setOrganismClassification(ms);
     }
@@ -135,6 +136,20 @@ public class MaterialSampleService extends MessageProducingService<MaterialSampl
     }
     String s = ScientificNameUtils.extractTargetOrganismPrimaryScientificName(sample.getOrganism());
     sample.setTargetOrganismPrimaryScientificName(s);
+  }
+
+  public void setTargetOrganismPrimaryTypeStatus(MaterialSample sample) {
+    if (CollectionUtils.isEmpty(sample.getOrganism())) {
+      return;
+    }
+
+    List<Organism> targetOrganisms = ScientificNameUtils.extractTargetOrganisms(sample.getOrganism());
+
+    if (targetOrganisms.size() == 1) {
+      sample.setTargetOrganismPrimaryTypeStatus(targetOrganisms.getFirst().getPrimaryDetermination().getTypeStatus());
+    } else {
+      log.debug("Multiple target organisms found, targetOrganismPrimaryTypeStatus won't be set");
+    }
   }
 
   public void setOrganismClassification(MaterialSample sample) {

--- a/src/test/java/ca/gc/aafc/collection/api/service/MaterialSampleServiceIT.java
+++ b/src/test/java/ca/gc/aafc/collection/api/service/MaterialSampleServiceIT.java
@@ -93,6 +93,7 @@ public class MaterialSampleServiceIT extends CollectionModuleBaseIT {
 
     Determination determination = DeterminationFactory.newDetermination()
             .verbatimScientificName("verbatimScientificName")
+            .typeStatus("typeStatus")
             .isPrimary(false)
             .build();
     Organism organism = OrganismEntityFactory.newOrganism()
@@ -122,6 +123,9 @@ public class MaterialSampleServiceIT extends CollectionModuleBaseIT {
 
     materialSampleService.setTargetOrganismPrimaryScientificName(parentMaterialSample);
     assertEquals("verbatimScientificName", parentMaterialSample.getTargetOrganismPrimaryScientificName());
+
+    materialSampleService.setTargetOrganismPrimaryTypeStatus(parentMaterialSample);
+    assertEquals("typeStatus", parentMaterialSample.getTargetOrganismPrimaryTypeStatus());
 
     //cleanup
     transactionTestingHelper.doInTransactionWithoutResult((s) -> materialSampleService.delete(materialSample));


### PR DESCRIPTION
- Added the new field.
- Updated the service to set this field if organism and primary determination is available.
- Added test coverage.