### PR TITLE
add German translations for initial values of system defined controlled vocabularies

### DIFF
--- a/src/main/resources/db/changelog/initial-data/3-Create_managed_attribute_controlled_vocabulary.xml
+++ b/src/main/resources/db/changelog/initial-data/3-Create_managed_attribute_controlled_vocabulary.xml
@@ -12,7 +12,7 @@
       <column name="type" value="MANAGED_ATTRIBUTE"/>
       <column name="vocab_class" value="QUALIFIED_VALUE"/>
       <column name="version" value="1"/>
-      <column name="multilingual_title" value='{"titles":[{"lang":"en","title":"Managed Attribute"},{"lang":"fr","title":"Attribut géré"}]}'/>
+      <column name="multilingual_title" value='{"titles":[{"lang":"en","title":"Managed Attribute"},{"lang":"fr","title":"Attribut géré"},{"lang":"de","title":"Regelattribut"}]}'/>
       <column name="multilingual_description" value='{
       "descriptions": [
       {
@@ -22,6 +22,10 @@
       {
       "lang": "fr",
       "desc": "Attributs pouvant être créés et utilisés sur demande par les utilisateurs. Ils sont généralement utilisés pour saisir des données qui ne sont pas suffisamment courantes pour être saisies dans un champ standard."
+      },
+      {
+      "lang": "de",
+      "desc": "Attribute, die von Benutzer:innen nach Bedarf erstellt und verwendet werden können. Sie werden normalerweise verwendet, um Daten zu erfassen, die nicht häufig genug sind, um in ein reguläres Feld aufgenommen zu werden."
       }
       ]
       }'/>

--- a/src/main/resources/db/changelog/initial-data/4-Create_coordinate_format_controlled_vocabulary.xml
+++ b/src/main/resources/db/changelog/initial-data/4-Create_coordinate_format_controlled_vocabulary.xml
@@ -12,7 +12,7 @@
             <column name="type" value="SYSTEM"/>
             <column name="vocab_class" value="CONTROLLED_TERM"/>
             <column name="version" value="1"/>
-            <column name="multilingual_title" value='{"titles":[{"lang":"en","title":"Coordinate Format"},{"lang":"fr","title":"Format de coordonnées"}]}'/>
+            <column name="multilingual_title" value='{"titles":[{"lang":"en","title":"Coordinate Format"},{"lang":"fr","title":"Format de coordonnées"},{"lang":"de","title":"Koordinatenformat"}]}'/>
             <column name="multilingual_description" value='{
       "descriptions": [
       {
@@ -22,6 +22,10 @@
       {
       "lang": "fr",
       "desc": " Manière d’écrire ou de représenter des positions géographiques sous forme textuelle, indépendamment du système de référence de coordonnées (SRC/CRS) ou du datum. Le format définit la structure, les unités et les symboles utilisés pour exprimer les coordonnées."
+      },
+      {
+      "lang": "de",
+      "desc": "Die Art, geografische Positionen als Text darzustellen, unabhängig vom Koordinatenreferenzsystem (CRS) oder Datum. Das Format definiert die Struktur, Einheiten und Symbole zur Darstellung von Koordinaten."
       }
       ]
       }'/>
@@ -35,7 +39,7 @@
             <column name="term" value="http://www.wikidata.org/entity/Q1798227"/>
             <column name="key" value="decimal_degrees"/>
             <column name="_group" value="system"/>
-            <column name="multilingual_title" value='{"titles":[{"lang":"en","title":"decimal degrees"},{"lang":"fr","title":"degrés décimaux"}]}'/>
+            <column name="multilingual_title" value='{"titles":[{"lang":"en","title":"decimal degrees"},{"lang":"fr","title":"degrés décimaux"},{"lang":"de","title":"Dezimalgrad"}]}'/>
             <column name="created_by" value="system"/>
         </insert>
         <insert tableName="controlled_vocabulary_item">
@@ -44,7 +48,7 @@
             <column name="name" value="degrees decimal minutes"/>
             <column name="key" value="degrees_decimal_minutes"/>
             <column name="_group" value="system"/>
-            <column name="multilingual_title" value='{"titles":[{"lang":"en","title":"degrees decimal minutes"},{"lang":"fr","title":"degrés décimales minutes"}]}'/>
+            <column name="multilingual_title" value='{"titles":[{"lang":"en","title":"degrees decimal minutes"},{"lang":"fr","title":"degrés décimales minutes"},{"lang":"de","title":"Grad Dezimalminuten"}]}'/>
             <column name="created_by" value="system"/>
         </insert>
         <insert tableName="controlled_vocabulary_item">
@@ -53,7 +57,7 @@
             <column name="name" value="degrees minutes seconds"/>
             <column name="key" value="degrees_minutes_seconds"/>
             <column name="_group" value="system"/>
-            <column name="multilingual_title" value='{"titles":[{"lang":"en","title":"degrees minutes seconds"},{"lang":"fr","title":"degrés minutes secondes"}]}'/>
+            <column name="multilingual_title" value='{"titles":[{"lang":"en","title":"degrees minutes seconds"},{"lang":"fr","title":"degrés minutes secondes"},{"lang":"de","title":"Grad Minuten Sekunden"}]}'/>
             <column name="created_by" value="system"/>
         </insert>
         <insert tableName="controlled_vocabulary_item">
@@ -63,7 +67,7 @@
             <column name="term" value="http://www.wikidata.org/wiki/Q588975"/>
             <column name="key" value="utm"/>
             <column name="_group" value="system"/>
-            <column name="multilingual_title" value='{"titles":[{"lang":"en","title":"Universal Transverse Mercator"},{"lang":"fr","title":"Transverse Universelle de Mercator"}]}'/>
+            <column name="multilingual_title" value='{"titles":[{"lang":"en","title":"Universal Transverse Mercator"},{"lang":"fr","title":"Transverse Universelle de Mercator"},{"lang":"de","title":"Universale Transversale Mercator"}]}'/>
             <column name="created_by" value="system"/>
         </insert>
     </changeSet>

--- a/src/main/resources/db/changelog/initial-data/5-Create_projectRole_controlled_vocabulary.xml
+++ b/src/main/resources/db/changelog/initial-data/5-Create_projectRole_controlled_vocabulary.xml
@@ -12,7 +12,7 @@
       <column name="type" value="SYSTEM"/>
       <column name="vocab_class" value="QUALIFIED_VALUE"/>
       <column name="version" value="1"/>
-      <column name="multilingual_title" value='{"titles":[{"lang":"en","title":"Project Role"},{"lang":"fr","title":"Rôle de projet"}]}'/>
+      <column name="multilingual_title" value='{"titles":[{"lang":"en","title":"Project Role"},{"lang":"fr","title":"Rôle de projet"},{"lang":"de","title":"Projektrolle"}]}'/>
       <column name="multilingual_description" value='{
       "descriptions": [
       {
@@ -22,6 +22,10 @@
       {
       "lang": "fr",
       "desc": "Rôles de projet qui définissent les responsabilités des individus au sein d’un projet."
+      },
+      {
+      "lang": "de",
+      "desc": "Rollen, die die Verantwortlichkeiten von Personen innerhalb eines Projekts definieren."
       }
       ]
       }'/>
@@ -35,7 +39,7 @@
             <column name="term" value=""/>
             <column name="key" value="project_leader"/>
             <column name="_group" value="system"/>
-            <column name="multilingual_title" value='{"titles":[{"lang":"en","title":"Project Leader"},{"lang":"fr","title":"Chef de projet"}]}'/>
+            <column name="multilingual_title" value='{"titles":[{"lang":"en","title":"Project Leader"},{"lang":"fr","title":"Chef de projet"},{"lang":"de","title":"Projektleiter"}]}'/>
             <column name="created_by" value="system"/>
         </insert>
 
@@ -46,7 +50,7 @@
             <column name="term" value=""/>
             <column name="key" value="project_member"/>
             <column name="_group" value="system"/>
-            <column name="multilingual_title" value='{"titles":[{"lang":"en","title":"Project Member"},{"lang":"fr","title":"Membre du projet"}]}'/>
+            <column name="multilingual_title" value='{"titles":[{"lang":"en","title":"Project Member"},{"lang":"fr","title":"Membre du projet"},{"lang":"de","title":"Projektmitglied"}]}'/>
             <column name="created_by" value="system"/>
         </insert>
 
@@ -57,7 +61,7 @@
             <column name="term" value=""/>
             <column name="key" value="data_curator"/>
             <column name="_group" value="system"/>
-            <column name="multilingual_title" value='{"titles":[{"lang":"en","title":"Data Curator"},{"lang":"fr","title":"Conservateur de données"}]}'/>
+            <column name="multilingual_title" value='{"titles":[{"lang":"en","title":"Data Curator"},{"lang":"fr","title":"Conservateur de données"},{"lang":"de","title":"Datenkurator"}]}'/>
             <column name="created_by" value="system"/>
         </insert>
 
@@ -68,7 +72,7 @@
             <column name="term" value=""/>
             <column name="key" value="data_manager"/>
             <column name="_group" value="system"/>
-            <column name="multilingual_title" value='{"titles":[{"lang":"en","title":"Data Manager"},{"lang":"fr","title":"Gestionnaire de données"}]}'/>
+            <column name="multilingual_title" value='{"titles":[{"lang":"en","title":"Data Manager"},{"lang":"fr","title":"Gestionnaire de données"},{"lang":"de","title":"Datenmanager"}]}'/>
             <column name="created_by" value="system"/>
         </insert>
 
@@ -79,7 +83,7 @@
             <column name="term" value=""/>
             <column name="key" value="contact_person"/>
             <column name="_group" value="system"/>
-            <column name="multilingual_title" value='{"titles":[{"lang":"en","title":"Contact Person"},{"lang":"fr","title":"Personne ressource"}]}'/>
+            <column name="multilingual_title" value='{"titles":[{"lang":"en","title":"Contact Person"},{"lang":"fr","title":"Personne ressource"},{"lang":"de","title":"Ansprechpartner"}]}'/>
             <column name="created_by" value="system"/>
         </insert>
   </changeSet>

--- a/src/main/resources/db/changelog/initial-data/6-Create_material_sample_identifier_type_controlled_vocabulary.xml
+++ b/src/main/resources/db/changelog/initial-data/6-Create_material_sample_identifier_type_controlled_vocabulary.xml
@@ -12,7 +12,7 @@
       <column name="type" value="SYSTEM"/>
       <column name="vocab_class" value="QUALIFIED_VALUE"/>
       <column name="version" value="1"/>
-      <column name="multilingual_title" value='{"titles":[{"lang":"en","title":"Identifier Type"},{"lang":"fr","title":"Type d’identifiant"}]}'/>
+      <column name="multilingual_title" value='{"titles":[{"lang":"en","title":"Identifier Type"},{"lang":"fr","title":"Type d’identifiant"},{"lang":"de","title":"Identifier-Typ"}]}'/>
       <column name="created_by" value="system"/>
     </insert>
   </changeSet>

--- a/src/main/resources/db/changelog/initial-data/7-Create_type_status_controlled_vocabulary.xml
+++ b/src/main/resources/db/changelog/initial-data/7-Create_type_status_controlled_vocabulary.xml
@@ -13,7 +13,7 @@
             <column name="type" value="SYSTEM"/>
             <column name="vocab_class" value="QUALIFIED_VALUE"/>
             <column name="version" value="1"/>
-            <column name="multilingual_title" value='{"titles":[{"lang":"en","title":"Type Status"},{"lang":"fr","title":"Statut du type"}]}'/>
+            <column name="multilingual_title" value='{"titles":[{"lang":"en","title":"Type Status"},{"lang":"fr","title":"Statut du type"},{"lang":"de","title":"Typstatus"}]}'/>
             <column name="multilingual_description" value='{
       "descriptions": [
       {
@@ -23,6 +23,10 @@
       {
       "lang": "fr",
       "desc": "Type nomenclatural appliqué au sujet"
+      },
+      {
+      "lang": "de",
+      "desc": "Nomenklaturlicher Typ, der auf das Objekt angewendet wird"
       }
       ]
       }'/>
@@ -36,7 +40,7 @@
             <column name="term" value=""/>
             <column name="key" value="none"/>
             <column name="_group" value="system"/>
-            <column name="multilingual_title" value='{"titles":[{"lang":"en","title":"None"},{"lang":"fr","title":"Aucun"}]}'/>
+            <column name="multilingual_title" value='{"titles":[{"lang":"en","title":"None"},{"lang":"fr","title":"Aucun"},{"lang":"de","title":"Keine"}]}'/>
             <column name="created_by" value="system"/>
         </insert>
 
@@ -47,7 +51,7 @@
             <column name="term" value="http://www.wikidata.org/entity/Q1061403"/>
             <column name="key" value="holotype"/>
             <column name="_group" value="system"/>
-            <column name="multilingual_title" value='{"titles":[{"lang":"en","title":"Holotype"},{"lang":"fr","title":"Holotype"}]}'/>
+            <column name="multilingual_title" value='{"titles":[{"lang":"en","title":"Holotype"},{"lang":"fr","title":"Holotype"},{"lang":"de","title":"Holotyp"}]}'/>
             <column name="created_by" value="system"/>
         </insert>
 
@@ -58,7 +62,7 @@
             <column name="term" value="http://www.wikidata.org/entity/Q926578"/>
             <column name="key" value="paratype"/>
             <column name="_group" value="system"/>
-            <column name="multilingual_title" value='{"titles":[{"lang":"en","title":"Paratype"},{"lang":"fr","title":"Paratype"}]}'/>
+            <column name="multilingual_title" value='{"titles":[{"lang":"en","title":"Paratype"},{"lang":"fr","title":"Paratype"},{"lang":"de","title":"Paratyp"}]}'/>
             <column name="created_by" value="system"/>
         </insert>
 
@@ -69,7 +73,7 @@
             <column name="term" value="http://www.wikidata.org/entity/Q19353437"/>
             <column name="key" value="allotype"/>
             <column name="_group" value="system"/>
-            <column name="multilingual_title" value='{"titles":[{"lang":"en","title":"Allotype"},{"lang":"fr","title":"Allotype"}]}'/>
+            <column name="multilingual_title" value='{"titles":[{"lang":"en","title":"Allotype"},{"lang":"fr","title":"Allotype"},{"lang":"de","title":"Allotyp"}]}'/>
             <column name="created_by" value="system"/>
         </insert>
 
@@ -80,7 +84,7 @@
             <column name="term" value="http://www.wikidata.org/entity/Q3874702"/>
             <column name="key" value="neotype"/>
             <column name="_group" value="system"/>
-            <column name="multilingual_title" value='{"titles":[{"lang":"en","title":"Neotype"},{"lang":"fr","title":"Neotype"}]}'/>
+            <column name="multilingual_title" value='{"titles":[{"lang":"en","title":"Neotype"},{"lang":"fr","title":"Neotype"},{"lang":"de","title":"Neotyp"}]}'/>
             <column name="created_by" value="system"/>
         </insert>
 
@@ -91,7 +95,7 @@
             <column name="term" value="http://www.wikidata.org/entity/Q719822"/>
             <column name="key" value="syntype"/>
             <column name="_group" value="system"/>
-            <column name="multilingual_title" value='{"titles":[{"lang":"en","title":"Syntype"},{"lang":"fr","title":"Syntype"}]}'/>
+            <column name="multilingual_title" value='{"titles":[{"lang":"en","title":"Syntype"},{"lang":"fr","title":"Syntype"},{"lang":"de","title":"Syntyp"}]}'/>
             <column name="created_by" value="system"/>
         </insert>
 
@@ -102,7 +106,7 @@
             <column name="term" value="http://www.wikidata.org/entity/Q2439719"/>
             <column name="key" value="lectotype"/>
             <column name="_group" value="system"/>
-            <column name="multilingual_title" value='{"titles":[{"lang":"en","title":"Lectotype"},{"lang":"fr","title":"Lectotype"}]}'/>
+            <column name="multilingual_title" value='{"titles":[{"lang":"en","title":"Lectotype"},{"lang":"fr","title":"Lectotype"},{"lang":"de","title":"Lectotyp"}]}'/>
             <column name="created_by" value="system"/>
         </insert>
 
@@ -113,7 +117,7 @@
             <column name="term" value="http://www.wikidata.org/entity/Q19353473"/>
             <column name="key" value="paralectotype"/>
             <column name="_group" value="system"/>
-            <column name="multilingual_title" value='{"titles":[{"lang":"en","title":"Paralectotype"},{"lang":"fr","title":"Paralectotype"}]}'/>
+            <column name="multilingual_title" value='{"titles":[{"lang":"en","title":"Paralectotype"},{"lang":"fr","title":"Paralectotype"},{"lang":"de","title":"Paralectotyp"}]}'/>
             <column name="created_by" value="system"/>
         </insert>
 
@@ -124,7 +128,7 @@
             <column name="term" value="http://www.wikidata.org/entity/Q19353478"/>
             <column name="key" value="hapantotype"/>
             <column name="_group" value="system"/>
-            <column name="multilingual_title" value='{"titles":[{"lang":"en","title":"Hapantotype"},{"lang":"fr","title":"Hapantotype"}]}'/>
+            <column name="multilingual_title" value='{"titles":[{"lang":"en","title":"Hapantotype"},{"lang":"fr","title":"Hapantotype"},{"lang":"de","title":"Hapantyp"}]}'/>
             <column name="created_by" value="system"/>
         </insert>
 
@@ -134,7 +138,7 @@
             <column name="name" value="Iconotype"/>
             <column name="key" value="iconotype"/>
             <column name="_group" value="system"/>
-            <column name="multilingual_title" value='{"titles":[{"lang":"en","title":"Iconotype"},{"lang":"fr","title":"Iconotype"}]}'/>
+            <column name="multilingual_title" value='{"titles":[{"lang":"en","title":"Iconotype"},{"lang":"fr","title":"Iconotype"},{"lang":"de","title":"Iconotyp"}]}'/>
             <column name="created_by" value="system"/>
         </insert>
 
@@ -145,7 +149,7 @@
             <column name="term" value="http://www.wikidata.org/entity/Q19353481"/>
             <column name="key" value="ergatotype"/>
             <column name="_group" value="system"/>
-            <column name="multilingual_title" value='{"titles":[{"lang":"en","title":"Ergatotype"},{"lang":"fr","title":"Ergatotype"}]}'/>
+            <column name="multilingual_title" value='{"titles":[{"lang":"en","title":"Ergatotype"},{"lang":"fr","title":"Ergatotype"},{"lang":"de","title":"Ergatotyp"}]}'/>
             <column name="created_by" value="system"/>
         </insert>
     </changeSet>

--- a/src/main/resources/db/changelog/initial-data/8-Create_association_type_controlled_vocabulary.xml
+++ b/src/main/resources/db/changelog/initial-data/8-Create_association_type_controlled_vocabulary.xml
@@ -13,7 +13,7 @@
             <column name="type" value="SYSTEM"/>
             <column name="vocab_class" value="QUALIFIED_VALUE"/>
             <column name="version" value="1"/>
-            <column name="multilingual_title" value='{"titles":[{"lang":"en","title":"Association Type"},{"lang":"fr","title":"Type d&apos;association"}]}'/>
+            <column name="multilingual_title" value='{"titles":[{"lang":"en","title":"Association Type"},{"lang":"fr","title":"Type d&apos;association"},{"lang":"de","title":"Beziehungsart"}]}'/>
             <column name="created_by" value="system"/>
         </insert>
 
@@ -24,12 +24,16 @@
             <column name="key" value="has_host"/>
             <column name="_group" value="system"/>
             <column name="term" value="http://purl.obolibrary.org/obo/RO_0002454"/>
-            <column name="multilingual_title" value='{"titles":[{"lang":"en","title":"Has host"}]}'/>
+            <column name="multilingual_title" value='{"titles":[{"lang":"en","title":"Has host"},{"lang":"de","title":"Hat Wirt"}]}'/>
             <column name="multilingual_description" value='{
                 "descriptions": [
                 {
                 "lang": "en",
                 "desc": "X has host y if and only if: x is an organism, y is an organism, and x can live on the surface of or within the body of y."
+                },
+                {
+                "lang": "de",
+                "desc": "X hat Wirt y genau dann, wenn: x ein Organismus ist, y ein Organismus ist und x auf der Oberfläche oder im Körper von y leben kann."
                 }
                 ]
                 }'/>
@@ -43,12 +47,16 @@
             <column name="key" value="host_of"/>
             <column name="_group" value="system"/>
             <column name="term" value="http://purl.obolibrary.org/obo/RO_0002453"/>
-            <column name="multilingual_title" value='{"titles":[{"lang":"en","title":"Host of"}]}'/>
+            <column name="multilingual_title" value='{"titles":[{"lang":"en","title":"Host of"},{"lang":"de","title":"Wirt von"}]}'/>
             <column name="multilingual_description" value='{
                 "descriptions": [
                 {
                 "lang": "en",
                 "desc": "Inverse of has host."
+                },
+                {
+                "lang": "de",
+                "desc": "Umkehrung von hat Wirt."
                 }
                 ]
                 }'/>
@@ -62,12 +70,16 @@
             <column name="key" value="parasite_of"/>
             <column name="_group" value="system"/>
             <column name="term" value="http://purl.obolibrary.org/obo/RO_0002444"/>
-            <column name="multilingual_title" value='{"titles":[{"lang":"en","title":"Parasite of"}]}'/>
+            <column name="multilingual_title" value='{"titles":[{"lang":"en","title":"Parasite of"},{"lang":"de","title":"Parasit von"}]}'/>
             <column name="multilingual_description" value='{
                 "descriptions": [
                 {
                 "lang": "en",
                 "desc": "A parasite-host relationship where an organism benefits at the expense of another."
+                },
+                {
+                "lang": "de",
+                "desc": "Eine Parasiten-Wirt-Beziehung, bei der ein Organismus auf Kosten eines anderen profitiert."
                 }
                 ]
                 }'/>
@@ -81,12 +93,16 @@
             <column name="key" value="parasitized_by"/>
             <column name="_group" value="system"/>
             <column name="term" value="http://purl.obolibrary.org/obo/RO_0002445"/>
-            <column name="multilingual_title" value='{"titles":[{"lang":"en","title":"Parasitized by"}]}'/>
+            <column name="multilingual_title" value='{"titles":[{"lang":"en","title":"Parasitized by"},{"lang":"de","title":"Parasitisiert von"}]}'/>
             <column name="multilingual_description" value='{
                 "descriptions": [
                 {
                 "lang": "en",
                 "desc": "Inverse of parasite of."
+                },
+                {
+                "lang": "de",
+                "desc": "Umkehrung von Parasit von."
                 }
                 ]
                 }'/>
@@ -100,12 +116,16 @@
             <column name="key" value="pollinates"/>
             <column name="_group" value="system"/>
             <column name="term" value="http://purl.obolibrary.org/obo/RO_0002455"/>
-            <column name="multilingual_title" value='{"titles":[{"lang":"en","title":"Pollinates"}]}'/>
+            <column name="multilingual_title" value='{"titles":[{"lang":"en","title":"Pollinates"},{"lang":"de","title":"Bestäubt"}]}'/>
             <column name="multilingual_description" value='{
                 "descriptions": [
                 {
                 "lang": "en",
                 "desc": "Inverse of pollinated by."
+                },
+                {
+                "lang": "de",
+                "desc": "Umkehrung von bestäubt durch."
                 }
                 ]
                 }'/>
@@ -119,12 +139,16 @@
             <column name="key" value="pollinated_by"/>
             <column name="_group" value="system"/>
             <column name="term" value="http://purl.obolibrary.org/obo/RO_0002456"/>
-            <column name="multilingual_title" value='{"titles":[{"lang":"en","title":"Pollinated by"}]}'/>
+            <column name="multilingual_title" value='{"titles":[{"lang":"en","title":"Pollinated by"},{"lang":"de","title":"Bestäubt durch"}]}'/>
             <column name="multilingual_description" value='{
                 "descriptions": [
                 {
                 "lang": "en",
                 "desc": "Inverse of pollinates."
+                },
+                {
+                "lang": "de",
+                "desc": "Umkehrung von bestäubt."
                 }
                 ]
                 }'/>
@@ -138,12 +162,16 @@
             <column name="key" value="has_vector"/>
             <column name="_group" value="system"/>
             <column name="term" value="http://purl.obolibrary.org/obo/RO_0002460"/>
-            <column name="multilingual_title" value='{"titles":[{"lang":"en","title":"Has vector"}]}'/>
+            <column name="multilingual_title" value='{"titles":[{"lang":"en","title":"Has vector"},{"lang":"de","title":"Hat Vektor"}]}'/>
             <column name="multilingual_description" value='{
                 "descriptions": [
                 {
                 "lang": "en",
                 "desc": "Inverse of is vector for."
+                },
+                {
+                "lang": "de",
+                "desc": "Umkehrung von ist Vektor für."
                 }
                 ]
                 }'/>
@@ -157,12 +185,16 @@
             <column name="key" value="vector_for"/>
             <column name="_group" value="system"/>
             <column name="term" value="http://purl.obolibrary.org/obo/RO_0002459"/>
-            <column name="multilingual_title" value='{"titles":[{"lang":"en","title":"Vector for"}]}'/>
+            <column name="multilingual_title" value='{"titles":[{"lang":"en","title":"Vector for"},{"lang":"de","title":"Vektor für"}]}'/>
             <column name="multilingual_description" value='{
                 "descriptions": [
                 {
                 "lang": "en",
                 "desc": "Inverse of has vector."
+                },
+                {
+                "lang": "de",
+                "desc": "Umkehrung von hat Vektor."
                 }
                 ]
                 }'/>
@@ -176,12 +208,16 @@
             <column name="key" value="has_pathogen"/>
             <column name="_group" value="system"/>
             <column name="term" value="http://purl.obolibrary.org/obo/RO_0002557"/>
-            <column name="multilingual_title" value='{"titles":[{"lang":"en","title":"Has pathogen"}]}'/>
+            <column name="multilingual_title" value='{"titles":[{"lang":"en","title":"Has pathogen"},{"lang":"de","title":"Hat Pathogen"}]}'/>
             <column name="multilingual_description" value='{
                 "descriptions": [
                 {
                 "lang": "en",
                 "desc": "A host interaction where the smaller of the two members of a symbiosis causes a disease in the larger member."
+                },
+                {
+                "lang": "de",
+                "desc": "Eine Wirtsinteraktion, bei der das kleinere der beiden Mitglieder einer Symbiose eine Krankheit beim größeren Mitglied verursacht."
                 }
                 ]
                 }'/>
@@ -195,12 +231,16 @@
             <column name="key" value="pathogen_of"/>
             <column name="_group" value="system"/>
             <column name="term" value="http://purl.obolibrary.org/obo/RO_0002556"/>
-            <column name="multilingual_title" value='{"titles":[{"lang":"en","title":"Pathogen of"}]}'/>
+            <column name="multilingual_title" value='{"titles":[{"lang":"en","title":"Pathogen of"},{"lang":"de","title":"Pathogen von"}]}'/>
             <column name="multilingual_description" value='{
                 "descriptions": [
                 {
                 "lang": "en",
                 "desc": "Inverse of has pathogen."
+                },
+                {
+                "lang": "de",
+                "desc": "Umkehrung von hat Pathogen."
                 }
                 ]
                 }'/>


### PR DESCRIPTION
I realized German labels were missing in a fresh DINA install for the initial controlled vocabularies.

Just a small PR, so I did not create a GH issue first, I hope that's okay @cgendreau 